### PR TITLE
Bugfix/kaleb coberly/move requests mock to required

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
     phonenumbers>=8.13.52,<9.0.0
     python-dotenv>=1.0.1,<2.0.0
     requests>=2.32.3,<3.0.0
+    requests-mock>=1.12.1,<2.0.0 # For testing, but included here so the minimal install test runs.
     typeguard>=4.4.1,<5.0.0
 
 [options.packages.find]
@@ -76,4 +77,3 @@ test =
     coverage[toml]>=7.2.7
     pytest>=7.4
     pytest-cov>=4.1
-    requests-mock>=1.12.1,<2.0.0


### PR DESCRIPTION
Moves requests_mock to required dependency. Only really needed for testing, so needed for final minimal test of published installs, but moving to required rather than change the shared workflow to install all test dependencies.