### PR TITLE
Feature/kaleb coberly/issue 59/make key retriever

### DIFF
--- a/src/bfb_delivery/lib/dispatch/utils.py
+++ b/src/bfb_delivery/lib/dispatch/utils.py
@@ -32,6 +32,7 @@ def get_circuit_key() -> str:
 # TODO: Pass params instead of forming URL first. ("params", not "json")
 # (Would need to then grab params URL for next page, or just add nextpage to params?)
 # https://github.com/crickets-and-comb/bfb_delivery/issues/61
+# TODO: bfb_delivery issue 59, comb_utils issue 24: Pass in paged response class?
 @typechecked
 def get_responses(url: str) -> list[dict[str, Any]]:
     """Get all responses from a paginated API endpoint."""
@@ -41,7 +42,7 @@ def get_responses(url: str) -> list[dict[str, Any]]:
     responses = []
 
     while next_page_salsa is not None:
-        paged_response_getter = api_callers.PagedResponseGetter(
+        paged_response_getter = api_callers.PagedResponseGetterBFB(
             page_url=url + str(next_page_cookie)
         )
         paged_response_getter.call_api()

--- a/tests/unit/test_api_callers.py
+++ b/tests/unit/test_api_callers.py
@@ -11,13 +11,13 @@ from typeguard import typechecked
 
 from bfb_delivery.lib.constants import CIRCUIT_URL, CircuitColumns, RateLimits
 from bfb_delivery.lib.dispatch.api_callers import (
+    BaseBFBDeleteCaller,
+    BaseBFBGetCaller,
+    BaseBFBPostCaller,
     BaseCaller,
-    BaseDeleteCaller,
-    BaseGetCaller,
-    BasePostCaller,
     OptimizationChecker,
     OptimizationLauncher,
-    PagedResponseGetter,
+    PagedResponseGetterBFB,
     PlanDeleter,
     PlanDistributor,
     PlanInitializer,
@@ -33,9 +33,9 @@ _MOCK_STOP_ARRAY: Final[list[dict[str, dict[str, str] | list[str] | int | str]]]
 ]
 
 _CALLER_DICT: Final[dict[str, type[BaseCaller]]] = {
-    "get": BaseGetCaller,
-    "post": BasePostCaller,
-    "delete": BaseDeleteCaller,
+    "get": BaseBFBGetCaller,
+    "post": BaseBFBPostCaller,
+    "delete": BaseBFBDeleteCaller,
     "opt_launcher": OptimizationLauncher,
     "opt_checker": OptimizationChecker,
     "stop_uploader": StopUploader,
@@ -635,12 +635,12 @@ def test_optimization_callers(
 )
 @typechecked
 def test_paged_getter(response_sequence: list[dict[str, Any]]) -> None:
-    """Test PagedResponseGetter."""
+    """Test PagedResponseGetterBFB."""
     with patch("requests.get") as mock_request:
         mock_request.side_effect = [Mock(**resp) for resp in response_sequence]
 
         page_url = "https://example.com/api/test"
-        caller = PagedResponseGetter(page_url=page_url)
+        caller = PagedResponseGetterBFB(page_url=page_url)
         caller.call_api()
         assert mock_request.call_args_list[0][1]["url"] == page_url
         assert caller.next_page_salsa == response_sequence[-1]["json.return_value"].get(

--- a/tests/unit/test_api_callers.py
+++ b/tests/unit/test_api_callers.py
@@ -83,6 +83,33 @@ _OPT_JSON_ERROR_CODE[CircuitColumns.RESULT] = {CircuitColumns.CODE: "MOCK_ERROR_
 
 
 @pytest.mark.parametrize("request_type", ["get", "post", "delete"])
+@typechecked
+def test_key_call(request_type: str) -> None:
+    """Test `call_api` handling of different HTTP responses, including retries."""
+
+    class MockCaller(_CALLER_DICT[request_type]):
+        """Minimal concrete subclass of BaseCaller for testing."""
+
+        def _set_url(self) -> None:
+            """Set a dummy test URL."""
+            self._url = "https://example.com/api/test"
+
+    response_sequence: list[dict[str, Any]] = [
+        {"json.return_value": {"data": [1, 2, 3]}, "status_code": 200}
+    ]
+
+    with patch(f"requests.{request_type}") as mock_request:
+        mock_request.side_effect = [Mock(**resp) for resp in response_sequence]
+        mock_caller = MockCaller()
+
+        with patch.object(
+            mock_caller, "_get_API_key", wraps=mock_caller._get_API_key
+        ) as spy_handle_get_API_key:
+            mock_caller.call_api()
+            spy_handle_get_API_key.assert_called_once()
+
+
+@pytest.mark.parametrize("request_type", ["get", "post", "delete"])
 @pytest.mark.parametrize(
     "response_sequence, expected_result, error_context",
     [


### PR DESCRIPTION
Adds `_get_API_key` abstract method to `BaseCaller`.
Creates `BaseKeyRetriever` with `_get_API_key` to wrap BFB `get_circuit_key`.
Wraps base callers into BFB callers which inherit `BaseKeyRetriever`.