### PR TITLE
Bugfix/kaleb coberly/debug fixture for act

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bfb_delivery
-version = 0.6.22
+version = 0.6.23
 description = Tools to help plan deliveries for Bellingham Food Bank.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/bfb_delivery/lib/dispatch/utils.py
+++ b/src/bfb_delivery/lib/dispatch/utils.py
@@ -21,7 +21,12 @@ def get_circuit_key() -> str:
     """Get the Circuit API key."""
     cwd = os_getcwd()
     print(f">> get_circuit_key is looking in: {cwd}")
-    load_dotenv(Path(cwd) / ".env")
+
+    env_path = Path(cwd) / ".env"
+    print(f">> checking if .env exists: {env_path.exists()}")
+    print(f">> .env contents:\n{env_path.read_text()}")
+    load_dotenv(env_path)
+
     key = os.getenv("CIRCUIT_API_KEY")
     print(f">> found CIRCUIT_API_KEY: {key}")
     if not key:

--- a/src/bfb_delivery/lib/dispatch/utils.py
+++ b/src/bfb_delivery/lib/dispatch/utils.py
@@ -19,8 +19,11 @@ logger = logging.getLogger(__name__)
 @typechecked
 def get_circuit_key() -> str:
     """Get the Circuit API key."""
-    load_dotenv(Path(os_getcwd()) / ".env")
+    cwd = os_getcwd()
+    print(f">> get_circuit_key is looking in: {cwd}")
+    load_dotenv(Path(cwd) / ".env")
     key = os.getenv("CIRCUIT_API_KEY")
+    print(f">> found CIRCUIT_API_KEY: {key}")
     if not key:
         raise ValueError(
             "Circuit API key not found. Set the CIRCUIT_API_KEY environment variable."

--- a/src/bfb_delivery/lib/dispatch/utils.py
+++ b/src/bfb_delivery/lib/dispatch/utils.py
@@ -19,16 +19,9 @@ logger = logging.getLogger(__name__)
 @typechecked
 def get_circuit_key() -> str:
     """Get the Circuit API key."""
-    cwd = os_getcwd()
-    print(f">> get_circuit_key is looking in: {cwd}")
-
-    env_path = Path(cwd) / ".env"
-    print(f">> checking if .env exists: {env_path.exists()}")
-    print(f">> .env contents:\n{env_path.read_text()}")
-    load_dotenv(dotenv_path=env_path, override=True)
+    load_dotenv(dotenv_path=Path(os_getcwd()) / ".env", override=True)
 
     key = os.getenv("CIRCUIT_API_KEY")
-    print(f">> found CIRCUIT_API_KEY: {key}")
     if not key:
         raise ValueError(
             "Circuit API key not found. Set the CIRCUIT_API_KEY environment variable."

--- a/src/bfb_delivery/lib/dispatch/utils.py
+++ b/src/bfb_delivery/lib/dispatch/utils.py
@@ -25,7 +25,7 @@ def get_circuit_key() -> str:
     env_path = Path(cwd) / ".env"
     print(f">> checking if .env exists: {env_path.exists()}")
     print(f">> .env contents:\n{env_path.read_text()}")
-    load_dotenv(env_path)
+    load_dotenv(dotenv_path=env_path, override=True)
 
     key = os.getenv("CIRCUIT_API_KEY")
     print(f">> found CIRCUIT_API_KEY: {key}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,12 +37,15 @@ def mock_get_circuit_key_dispatch_utils(
     mock_dispatch_utils_circuit_key: str, tmp_path: Path
 ) -> Iterator:
     """Mock get_circuit_key."""
+    print(">> mock_get_circuit_key_dispatch_utils IS RUNNING")
     env_path = tmp_path / ".env"
     env_path.write_text(f"CIRCUIT_API_KEY={mock_dispatch_utils_circuit_key}")
+    print(f">> writing .env to {env_path}")
     with patch(
         "bfb_delivery.lib.dispatch.utils.os_getcwd", return_value=tmp_path
     ) as mock_getcwd:
         mock_getcwd.return_value = tmp_path
+        print(">> patching os_getcwd to return", tmp_path)
         yield
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,15 +37,13 @@ def mock_get_circuit_key_dispatch_utils(
     mock_dispatch_utils_circuit_key: str, tmp_path: Path
 ) -> Iterator:
     """Mock get_circuit_key."""
-    print(">> mock_get_circuit_key_dispatch_utils IS RUNNING")
     env_path = tmp_path / ".env"
     env_path.write_text(f"CIRCUIT_API_KEY={mock_dispatch_utils_circuit_key}")
-    print(f">> writing .env to {env_path}")
+
     with patch(
         "bfb_delivery.lib.dispatch.utils.os_getcwd", return_value=tmp_path
     ) as mock_getcwd:
         mock_getcwd.return_value = tmp_path
-        print(">> patching os_getcwd to return", tmp_path)
         yield
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,17 +26,17 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
 
 
 @pytest.fixture
-def FAKE_KEY() -> str:
+def mock_dispatch_utils_circuit_key() -> str:
     """Fake Circuit API key."""
-    return "dispatch_utils_key"
+    return "dispatch_utils_circuit_key"
 
 
 @pytest.fixture(autouse=True)
 @typechecked
-def mock_get_circuit_key_dispatch_utils(FAKE_KEY: str, tmp_path: Path) -> Iterator:
+def mock_get_circuit_key_dispatch_utils(mock_dispatch_utils_circuit_key: str, tmp_path: Path) -> Iterator:
     """Mock get_circuit_key."""
     env_path = tmp_path / ".env"
-    env_path.write_text(f"CIRCUIT_API_KEY={FAKE_KEY}")
+    env_path.write_text(f"CIRCUIT_API_KEY={mock_dispatch_utils_circuit_key}")
     with patch(
         "bfb_delivery.lib.dispatch.utils.os_getcwd", return_value=tmp_path
     ) as mock_getcwd:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,9 @@ def mock_dispatch_utils_circuit_key() -> str:
 
 @pytest.fixture(autouse=True)
 @typechecked
-def mock_get_circuit_key_dispatch_utils(mock_dispatch_utils_circuit_key: str, tmp_path: Path) -> Iterator:
+def mock_get_circuit_key_dispatch_utils(
+    mock_dispatch_utils_circuit_key: str, tmp_path: Path
+) -> Iterator:
     """Mock get_circuit_key."""
     env_path = tmp_path / ".env"
     env_path.write_text(f"CIRCUIT_API_KEY={mock_dispatch_utils_circuit_key}")

--- a/tests/unit/test_dispatch_utils.py
+++ b/tests/unit/test_dispatch_utils.py
@@ -255,4 +255,5 @@ def test_get_responses_urls(responses: list[dict[str, Any]], params: str) -> Non
 @typechecked
 def test_get_circuit_key(mock_dispatch_utils_circuit_key: str) -> None:
     """Test get_circuit_key function."""
-    assert get_circuit_key() == mock_dispatch_utils_circuit_key
+    circuit_key = get_circuit_key()
+    assert circuit_key == mock_dispatch_utils_circuit_key

--- a/tests/unit/test_dispatch_utils.py
+++ b/tests/unit/test_dispatch_utils.py
@@ -256,4 +256,5 @@ def test_get_responses_urls(responses: list[dict[str, Any]], params: str) -> Non
 def test_get_circuit_key(mock_dispatch_utils_circuit_key: str) -> None:
     """Test get_circuit_key function."""
     circuit_key = get_circuit_key()
+    print(f"circuit_key: {circuit_key}")
     assert circuit_key == mock_dispatch_utils_circuit_key

--- a/tests/unit/test_dispatch_utils.py
+++ b/tests/unit/test_dispatch_utils.py
@@ -256,5 +256,4 @@ def test_get_responses_urls(responses: list[dict[str, Any]], params: str) -> Non
 def test_get_circuit_key(mock_dispatch_utils_circuit_key: str) -> None:
     """Test get_circuit_key function."""
     circuit_key = get_circuit_key()
-    print(f"circuit_key: {circuit_key}")
     assert circuit_key == mock_dispatch_utils_circuit_key

--- a/tests/unit/test_dispatch_utils.py
+++ b/tests/unit/test_dispatch_utils.py
@@ -253,6 +253,6 @@ def test_get_responses_urls(responses: list[dict[str, Any]], params: str) -> Non
 
 
 @typechecked
-def test_get_circuit_key(FAKE_KEY: str) -> None:
+def test_get_circuit_key(mock_dispatch_utils_circuit_key: str) -> None:
     """Test get_circuit_key function."""
-    assert get_circuit_key() == FAKE_KEY
+    assert get_circuit_key() == mock_dispatch_utils_circuit_key

--- a/tests/unit/test_read_circuit.py
+++ b/tests/unit/test_read_circuit.py
@@ -761,7 +761,9 @@ class TestCreateManifestsFromCircuit:
             (bad_df[IntermediateColumns.DRIVER_SHEET_NAME] == first_group)
             & (bad_df[Columns.STOP_NO] == max_first_group),
             Columns.STOP_NO,
-        ] = (max_first_group + 1)
+        ] = (
+            max_first_group + 1
+        )
 
         with pytest.raises(ValidationError, match="contiguous_group"):
             _write_routes_dfs(routes_df=bad_df, output_dir=tmp_path)


### PR DESCRIPTION
Overrides extant env vars with vars in .env from `load_dotenv` when getting Circuit key. Necessary to get `act` to act right.

Also:
- Renames fixture.
- Updates `shared` git submodule.