### PR TITLE
Bugfix/kaleb coberly/fix cli doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bellingham Food Bank delivery planning toolkit
 
-This set of command-line tools cuts some cruft around creating delivery route manifests for the Bellingham Food Bank. It saves an estimated five paid staff hours per week, along with removing much of the room for error. See the docs for user guides: https://crickets-and-comb.github.io/bfb_delivery/.
+This set of command-line tools cuts some cruft around creating delivery route manifests for the Bellingham Food Bank. It saves an estimated five paid staff hours per week, along with removing much of the room for error. See the docs for user guides: https://cricketsandcomb.org/bfb_delivery/.
 
 This is a [Crickets and Comb](https://cricketsandcomb.org) solution.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bfb_delivery
-version = 1.0.1
+version = 1.0.2
 description = Tools to help plan deliveries for Bellingham Food Bank.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/bfb_delivery/cli/build_routes_from_chunked.py
+++ b/src/bfb_delivery/cli/build_routes_from_chunked.py
@@ -1,7 +1,7 @@
 # noqa: D100
 __doc__ = """
 .. click:: bfb_delivery.cli.build_routes_from_chunked:main
-    :prog: create_manifests_from_circuit
+    :prog: build_routes_from_chunked
     :nested: full
 """
 

--- a/src/bfb_delivery/cli/create_manifests.py
+++ b/src/bfb_delivery/cli/create_manifests.py
@@ -1,7 +1,7 @@
 # noqa: D100
 __doc__ = """
-.. click:: bfb_delivery.cli.combine_route_tables:main
-   :prog: combine_route_tables
+.. click:: bfb_delivery.cli.create_manifests:main
+   :prog: create_manifests
    :nested: full
 """
 


### PR DESCRIPTION
Corrects a couple of `click` docstring `sphinx` objects, so they reference the correct docstrings and functions.

Also updates the README to point to docs on `cricketsandcomb.org` instead of directly to GitHub-hosted site.