### PR TITLE
Bugfix/kaleb coberly/assign neighborhood to external

### DIFF
--- a/scripts/clean_test_read_responses.py
+++ b/scripts/clean_test_read_responses.py
@@ -76,7 +76,7 @@ for all_hhs in ["_all_hhs", ""]:
                                 "addressLineTwo": f"stop-{i}-{j} addressLineTwo",
                                 "placeId": stop["address"]["placeId"],
                             },
-                            "notes": stop["notes"],
+                            "notes": "",
                             "packageCount": stop["packageCount"],
                             "stopPosition": stop["stopPosition"],
                             "orderInfo": {"products": stop["orderInfo"]["products"]},

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bfb_delivery
-version = 1.0.2
+version = 1.0.3
 description = Tools to help plan deliveries for Bellingham Food Bank.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/bfb_delivery/lib/dispatch/read_circuit.py
+++ b/src/bfb_delivery/lib/dispatch/read_circuit.py
@@ -387,6 +387,7 @@ def _pare_routes_df(routes_df: pd.DataFrame, verbose: bool) -> pd.DataFrame:
     return routes_df
 
 
+# TODO: Remove unused verbose flag.
 @typechecked
 def _set_routes_df_values(routes_df: pd.DataFrame, verbose: bool) -> pd.DataFrame:
     routes_df[IntermediateColumns.ROUTE_TITLE] = routes_df[CircuitColumns.ROUTE].apply(
@@ -459,8 +460,6 @@ def _warn_and_impute(routes_df: pd.DataFrame) -> None:
         )
     routes_df[Columns.ORDER_COUNT] = routes_df[Columns.ORDER_COUNT].fillna(1)
 
-    # TODO: Before we impute from Circuit, we should impute from user input spreadsheet.
-    # https://github.com/crickets-and-comb/bfb_delivery/issues/60
     missing_neighborhood = routes_df[Columns.NEIGHBORHOOD].isna()
     if missing_neighborhood.any():
         logger.warning(

--- a/src/bfb_delivery/lib/dispatch/read_circuit.py
+++ b/src/bfb_delivery/lib/dispatch/read_circuit.py
@@ -277,7 +277,7 @@ def _transform_routes_df(
         inplace=True,
     )
 
-    routes_df = _set_routes_df_values(routes_df=routes_df, verbose=verbose)
+    routes_df = _set_routes_df_values(routes_df=routes_df)
 
     routes_df.sort_values(
         by=[IntermediateColumns.DRIVER_SHEET_NAME, Columns.STOP_NO], inplace=True
@@ -387,9 +387,8 @@ def _pare_routes_df(routes_df: pd.DataFrame, verbose: bool) -> pd.DataFrame:
     return routes_df
 
 
-# TODO: Remove unused verbose flag.
 @typechecked
-def _set_routes_df_values(routes_df: pd.DataFrame, verbose: bool) -> pd.DataFrame:
+def _set_routes_df_values(routes_df: pd.DataFrame) -> pd.DataFrame:
     routes_df[IntermediateColumns.ROUTE_TITLE] = routes_df[CircuitColumns.ROUTE].apply(
         lambda route_dict: route_dict.get(CircuitColumns.TITLE)
     )

--- a/src/bfb_delivery/lib/dispatch/write_to_circuit.py
+++ b/src/bfb_delivery/lib/dispatch/write_to_circuit.py
@@ -936,6 +936,8 @@ def _build_stop_array(route_stops: pd.DataFrame, driver_id: str) -> list[dict[st
             recipient_dict[CircuitColumns.PHONE] = stop_row[Columns.PHONE]
         if stop_row.get(Columns.NAME) and not pd.isna(stop_row[Columns.NAME]):
             recipient_dict[CircuitColumns.NAME] = stop_row[Columns.NAME]
+        if stop_row.get(Columns.NEIGHBORHOOD) and not pd.isna(stop_row[Columns.NEIGHBORHOOD]):
+            recipient_dict[CircuitColumns.EXTERNAL_ID] = stop_row[Columns.NEIGHBORHOOD]
         if recipient_dict:
             stop[CircuitColumns.RECIPIENT] = recipient_dict
 

--- a/tests/unit/fixtures/stops_responses.json
+++ b/tests/unit/fixtures/stops_responses.json
@@ -11,7 +11,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -19,7 +19,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/0IWNayD8NEkvD5fQe2SQ",
                     "route": {
@@ -38,7 +39,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "EkpDYXNjYWRlIE1lYWRvdyBBcGFydG1lbnRzLCA0OTUgV2VzdGVybHkgUmQgIzMwNCwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJw2uk51mjhVQRk3UCXUx5rQMSAzMwNA"
                     },
-                    "notes": "Cascade Meadows Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -48,7 +49,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/0IWNayD8NEkvD5fQe2SQ",
                     "route": {
@@ -67,7 +69,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "Ei80MTYgV2VzdGVybHkgUmQgIzEwMywgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSI6GjgKMRIvChQKEglNkTnoWaOFVBGuH8qTmhZpbxCgAyoUChIJ3YmUU1ijhVQRi3UBqMufousSAzEwMw"
                     },
-                    "notes": "Cascade Meadows Apartments* - Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -77,7 +79,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/0IWNayD8NEkvD5fQe2SQ",
                     "route": {
@@ -96,7 +99,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "Ei80MTYgV2VzdGVybHkgUmQgIzEwNCwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSI6GjgKMRIvChQKEglNkTnoWaOFVBGuH8qTmhZpbxCgAyoUChIJ3YmUU1ijhVQRi3UBqMufousSAzEwNA"
                     },
-                    "notes": "Cascade Meadows Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -106,7 +109,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/0IWNayD8NEkvD5fQe2SQ",
                     "route": {
@@ -125,7 +129,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "Ei80OTEgV2VzdGVybHkgUmQgIzEwMSwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJE26g-lmjhVQR_OOr5AmypcESAzEwMQ"
                     },
-                    "notes": "Cascade Meadows Apartments* - Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -135,7 +139,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/0IWNayD8NEkvD5fQe2SQ",
                     "route": {
@@ -154,7 +159,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "Ei80MTYgV2VzdGVybHkgUmQgIzEwMiwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSI6GjgKMRIvChQKEglNkTnoWaOFVBGuH8qTmhZpbxCgAyoUChIJ3YmUU1ijhVQRi3UBqMufousSAzEwMg"
                     },
-                    "notes": "Cascade Meadows Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -164,7 +169,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/0IWNayD8NEkvD5fQe2SQ",
                     "route": {
@@ -183,7 +189,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "Ei80OTkgV2VzdGVybHkgUmQgIzIwNCwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJTdNM41mjhVQR_ynHERysW5ASAzIwNA"
                     },
-                    "notes": "Cascade Meadows Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -193,7 +199,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/0IWNayD8NEkvD5fQe2SQ",
                     "route": {
@@ -212,7 +219,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "Ei80MDQgV2VzdGVybHkgUmQgIzMwMiwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJYcU8uVmjhVQRzOuiXhlTCAISAzMwMg"
                     },
-                    "notes": "Cascade Meadows Apartments* - PLEASE DO NOT KNOCK",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -222,7 +229,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/0IWNayD8NEkvD5fQe2SQ",
                     "route": {
@@ -241,7 +249,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "Ei80MjQgV2VzdGVybHkgUmQgIzEwMywgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJXyWXz1mjhVQRw3Ei8wpk9ioSAzEwMw"
                     },
-                    "notes": "Cascade Meadows Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -251,7 +259,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/0IWNayD8NEkvD5fQe2SQ",
                     "route": {
@@ -270,7 +279,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "Ei80MDggV2VzdGVybHkgUmQgIzEwMiwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJSbrYulmjhVQR7ZXbEgDQnDwSAzEwMg"
                     },
-                    "notes": "Cascade Meadows Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -280,7 +289,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/0IWNayD8NEkvD5fQe2SQ",
                     "route": {
@@ -304,7 +314,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "Ei80OTkgV2VzdGVybHkgUmQgIzMwMywgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJTdNM41mjhVQR_ynHERysW5ASAzMwMw"
                     },
-                    "notes": "Cascade Meadows Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -314,7 +324,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/0IWNayD8NEkvD5fQe2SQ",
                     "route": {
@@ -333,7 +344,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "Ei80NzUgV2VzdGVybHkgUmQgIzEwMSwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJXabGilmjhVQRUhxn9Jc5ZD4SAzEwMQ"
                     },
-                    "notes": "Cascade Meadows Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -343,7 +354,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/0IWNayD8NEkvD5fQe2SQ",
                     "route": {
@@ -362,7 +374,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "Ei80NTkgV2VzdGVybHkgUmQgIzEwNCwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJg3O06lmjhVQRNiSj5SdY8WoSAzEwNA"
                     },
-                    "notes": "Cascade Meadows Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -372,7 +384,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/0IWNayD8NEkvD5fQe2SQ",
                     "route": {
@@ -398,7 +411,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "ChIJcS9a5KW1hVQRFip7S8rb1s4"
                     },
-                    "notes": "Walk along the trailer with a tree out front (#9), passing the 2nd entrance, to deliver to the door of the shed add-on to trailer #9. Celia picks up her box from here. Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 22,
                     "orderInfo": {
@@ -408,7 +421,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -427,7 +441,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "ChIJVz6bXpC7hVQRd8GxdtCk_IQ"
                     },
-                    "notes": "Recipient lives in a brand new unit at the Moles Cemetery. Please deliver directly to apartment door which is at athe back of the building and is marked  Apt 1.  There is a door to the left of her door that says  Employee access only.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 37,
                     "orderInfo": {
@@ -437,7 +451,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -456,7 +471,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "EiUzMTYgRnJvbnQgU3QgIzIsIFN1bWFzLCBXQSA5ODI5NSwgVVNBIh0aGwoWChQKEgkn6OVFNkuEVBFRIsqtfq1F_xIBMg"
                     },
-                    "notes": "Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 16,
                     "orderInfo": {
@@ -466,7 +481,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -493,7 +509,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -512,7 +529,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "ChIJl1-e-uq1hVQRcQlWY-7zcAU"
                     },
-                    "notes": "No specific delivery notes were provided, please let Team HD know if it is not obvious where to leave the delivery. Recipient is Mixteco-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 23,
                     "orderInfo": {
@@ -522,7 +539,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -541,7 +559,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "ChIJBda0TTO3hVQR-RMPfccAZq0"
                     },
-                    "notes": "Back porch",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -551,7 +569,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -570,7 +589,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "ChIJu8WaLFa3hVQRW8NkXGg4gNI"
                     },
-                    "notes": "Leave on table out front.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 30,
                     "orderInfo": {
@@ -580,7 +599,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -599,7 +619,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "ChIJ_RMwqRi6hVQRcgaSzfJYD6s"
                     },
-                    "notes": "Deliver to front door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 32,
                     "orderInfo": {
@@ -609,7 +629,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -628,7 +649,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "ChIJu4p_4ym5hVQR1aKwJvkJ0lM"
                     },
-                    "notes": "Double L Mobile Ranch - Deliver to porch",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 43,
                     "orderInfo": {
@@ -638,7 +659,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -657,7 +679,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "ChIJzWhjWmVLhFQR-x9yT29OpLg"
                     },
-                    "notes": "Two families receiving deliveries live at this address. Please deliver both boxes to front door. Recipients are Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 18,
                     "orderInfo": {
@@ -667,7 +689,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -691,7 +714,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "ChIJ2dXdsjtLhFQRS3JdC97UbHg"
                     },
-                    "notes": "Please deliver to front porch.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 20,
                     "orderInfo": {
@@ -701,7 +724,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -720,7 +744,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "ChIJ1eMAEGC2hVQRte1MgBbiDQ4"
                     },
-                    "notes": "Please deliver to front porch. Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 24,
                     "orderInfo": {
@@ -730,7 +754,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -749,7 +774,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "ChIJM1k9h960hVQRt4mKGS0GzZU"
                     },
-                    "notes": "White house with black time and a red barn behind it, right across the street from Crape Rd. Park in the gravel area just behind the house. Deliver box inside the front porch, if possible.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 21,
                     "orderInfo": {
@@ -759,7 +784,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -778,7 +804,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "ChIJ02A0fFa2hVQR_094ZTxRahg"
                     },
-                    "notes": "Deliver to front porch. Alternative phone number is 360-354-3341. Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 26,
                     "orderInfo": {
@@ -788,7 +814,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -807,7 +834,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "ChIJR52qeEK6hVQR-p0oT5rZqjY"
                     },
-                    "notes": "Recipient's house is at the end of a long driveway. Driveway entrance is the first road on the right after Chasteen if you're heading west on Ten Mile. Deliver to the green house in the middle.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 34,
                     "orderInfo": {
@@ -817,7 +844,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -836,7 +864,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "ChIJ9wbHuFG5hVQRKC5AHMgmr-I"
                     },
-                    "notes": "If facing East, the driveway is on the righthand side of Trigg Rd. It's a longer driveway with many cars on the lot and an above ground pool in the yard.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 40,
                     "orderInfo": {
@@ -846,7 +874,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -865,7 +894,7 @@
                         "addressLineTwo": "stop-1-6 addressLineTwo",
                         "placeId": "ChIJd2hzhNWwhVQR6vked4nc0R4"
                     },
-                    "notes": "From Hannegan, take Van Dyk Rd east. Pass berry fields on the left and see a seasonal pond. Go to the driveway after the pond and ground level house. You will be at roof level when you drive in. Take the path to the front door on the right side.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -875,7 +904,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -894,7 +924,7 @@
                         "addressLineTwo": "stop-1-7 addressLineTwo",
                         "placeId": "ChIJnXk0UVS5hVQRc9gliDldozo"
                     },
-                    "notes": "Portal Creek Park",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 39,
                     "orderInfo": {
@@ -904,7 +934,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -923,7 +954,7 @@
                         "addressLineTwo": "stop-1-8 addressLineTwo",
                         "placeId": "ChIJybGBx0pLhFQRqEC2VjcYQRU"
                     },
-                    "notes": "Sumas Trailer Park - Please deliver to door step.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -933,7 +964,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -952,7 +984,7 @@
                         "addressLineTwo": "stop-1-9 addressLineTwo",
                         "placeId": "ChIJz070lj-5hVQRhM34lRAonVk"
                     },
-                    "notes": "Driveway is marked with an eagle sculpture. Deliver to house and Cheryl will pick up the box from there. Please text her when the delivery is made.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 42,
                     "orderInfo": {
@@ -962,7 +994,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -986,7 +1019,7 @@
                         "addressLineTwo": "stop-2-0 addressLineTwo",
                         "placeId": "ChIJ6x6s1wa7hVQRjadvEEfigJ4"
                     },
-                    "notes": "Front porch",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 35,
                     "orderInfo": {
@@ -996,7 +1029,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -1015,7 +1049,7 @@
                         "addressLineTwo": "stop-2-1 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -1023,7 +1057,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -1052,7 +1087,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -1071,7 +1107,7 @@
                         "addressLineTwo": "stop-2-3 addressLineTwo",
                         "placeId": "ChIJu4p_4ym5hVQR1aKwJvkJ0lM"
                     },
-                    "notes": "Double L Mobile Ranch - Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 44,
                     "orderInfo": {
@@ -1081,7 +1117,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -1110,7 +1147,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -1129,7 +1167,7 @@
                         "addressLineTwo": "stop-2-5 addressLineTwo",
                         "placeId": "Eig4MDEgQWFyb24gRHIgIzEyMiwgTHluZGVuLCBXQSA5ODI2NCwgVVNBIh8aHQoWChQKEglfF3inXraFVBGqU-7bIYIeIxIDMTIy"
                     },
-                    "notes": "Parkview West Apartments - Please look for recipient's unit on the east side of the building.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 25,
                     "orderInfo": {
@@ -1139,7 +1177,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -1158,7 +1197,7 @@
                         "addressLineTwo": "stop-2-6 addressLineTwo",
                         "placeId": "ChIJU-d3dvK2hVQRTnuYHXIC12c"
                     },
-                    "notes": "Viewcrest Mobile Home Park - Recipient's mobile home does not have a number on it. It is pale green with a silver roof. Please deliver to front porch. Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -1168,7 +1207,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -1187,7 +1227,7 @@
                         "addressLineTwo": "stop-2-7 addressLineTwo",
                         "placeId": "Eis5MzIgVyBBeHRvbiBSZCBhLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh0aGwoWChQKEgkLrTccmruFVBEWjkukpXO2DxIBYQ"
                     },
-                    "notes": "Axton House/Lakeside - This is a group home. Pull up to big house and knock on the door. Unit A is upstairs.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 36,
                     "orderInfo": {
@@ -1197,7 +1237,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -1216,7 +1257,7 @@
                         "addressLineTwo": "stop-2-8 addressLineTwo",
                         "placeId": "ChIJt56eiL26hVQRlPJEtrK0a9c"
                     },
-                    "notes": "Deliver to the the first structure on the right as you're coming up the driveway.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -1226,7 +1267,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -1245,7 +1287,7 @@
                         "addressLineTwo": "stop-2-9 addressLineTwo",
                         "placeId": "EiIzMTMgMTR0aCBTdCwgTHluZGVuLCBXQSA5ODI2NCwgVVNBIjESLwoUChIJ3yKNQg-3hVQR0xQGC3FRWcoQuQIqFAoSCVH5-PcFt4VUEWIwZ8c9E6oM"
                     },
-                    "notes": "La Villa Apartments - building is on 14th St off of Liberty St. Rrecipient's unit is on the 2nd floor and has a  313  on the door, no specific unit number otherwise. Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 29,
                     "orderInfo": {
@@ -1255,7 +1297,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -1279,7 +1322,7 @@
                         "addressLineTwo": "stop-3-0 addressLineTwo",
                         "placeId": "EicxNDAwIEJvb24gU3QgIzExOSwgU3VtYXMsIFdBIDk4Mjk1LCBVU0EiHxodChYKFAoSCZMEBwBKS4RUEQhxlyp4jq1xEgMxMTk"
                     },
-                    "notes": "Creekside Meadows. Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -1289,7 +1332,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -1318,7 +1362,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -1337,7 +1382,7 @@
                         "addressLineTwo": "stop-3-2 addressLineTwo",
                         "placeId": "ChIJ6wMPg_y2hVQR_m_xEhH_whg"
                     },
-                    "notes": "House has a purple front door. Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -1347,7 +1392,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -1366,7 +1412,7 @@
                         "addressLineTwo": "stop-3-3 addressLineTwo",
                         "placeId": "EiQ0MDQgRnJvbnQgU3QgYiwgU3VtYXMsIFdBIDk4Mjk1LCBVU0EiHRobChYKFAoSCaOsbDU2S4RUEX4wTsdviIydEgFi"
                     },
-                    "notes": "There may be a tree blocking the address.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 17,
                     "orderInfo": {
@@ -1376,7 +1422,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -1395,7 +1442,7 @@
                         "addressLineTwo": "stop-3-4 addressLineTwo",
                         "placeId": "ChIJzWhjWmVLhFQR-x9yT29OpLg"
                     },
-                    "notes": "Two families receiving deliveries live at this address. Please deliver both boxes to front door. Recipients are Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 19,
                     "orderInfo": {
@@ -1405,7 +1452,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -1424,7 +1472,7 @@
                         "addressLineTwo": "stop-3-5 addressLineTwo",
                         "placeId": "ChIJVbmjnjK5hVQR2CNnk2jtZYQ"
                     },
-                    "notes": "Fairfield Mobile Park - Deliver to front porch.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 45,
                     "orderInfo": {
@@ -1434,7 +1482,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -1453,7 +1502,7 @@
                         "addressLineTwo": "stop-3-6 addressLineTwo",
                         "placeId": "Eik4NjExIERlcG90IFJkICMxMDIsIEx5bmRlbiwgV0EgOTgyNjQsIFVTQSIfGh0KFgoUChIJU-4ohVW2hVQRW91CsGvdfkUSAzEwMg"
                     },
-                    "notes": "Apple Valley Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 28,
                     "orderInfo": {
@@ -1463,7 +1512,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -1482,7 +1532,7 @@
                         "addressLineTwo": "stop-3-7 addressLineTwo",
                         "placeId": "ChIJd9UcDdW6hVQRISE-kCYt4g0"
                     },
-                    "notes": "Driveway is easy to miss. It's on the west side of Hannegan, look for a small blue sign with the street number. Look for the house just past the set of trailer homes on the left and deliver to the front porch.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -1492,7 +1542,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -1511,7 +1562,7 @@
                         "addressLineTwo": "stop-3-8 addressLineTwo",
                         "placeId": "EikxNTgwIE1haW4gU3QgIzIzLCBGZXJuZGFsZSwgV0EgOTgyNDgsIFVTQSIeGhwKFgoUChIJF5w7yHS8hVQRdE0xQNAaLxwSAjIz"
                     },
-                    "notes": "Worcester Venure Trailer Park - Please deliver to trailer #23.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 38,
                     "orderInfo": {
@@ -1521,7 +1572,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -1540,7 +1592,7 @@
                         "addressLineTwo": "stop-3-9 addressLineTwo",
                         "placeId": "ChIJpeWrEJW0hVQRYtoOliAMZmA"
                     },
-                    "notes": "Address numbers can be difficult to see from the road. Recipient lives in the biege one-story home with white trim and a large front yard, the last farm on the south side of the road if you're heading east, between Nooksack Ave and Garrison Rd. Please note you may hear dogs barking inside when making the delivery, they cannot get out of the house.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -1550,7 +1602,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -1584,7 +1637,8 @@
                     },
                     "recipient": {
                         "name": "stop-4-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -1613,7 +1667,8 @@
                     },
                     "recipient": {
                         "name": "stop-4-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -1632,7 +1687,7 @@
                         "addressLineTwo": "stop-4-2 addressLineTwo",
                         "placeId": "ChIJy5qEHOWkhVQROIM60sUQ-uY"
                     },
-                    "notes": "Take the gravel driveway off of Dewey Rd and deliver to the first house going up the driveway, it is gray.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -1642,7 +1697,8 @@
                     },
                     "recipient": {
                         "name": "stop-4-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -1661,7 +1717,7 @@
                         "addressLineTwo": "stop-4-3 addressLineTwo",
                         "placeId": "Eio3MzQzIEhhbm5lZ2FuIFJkICM3LCBMeW5kZW4sIFdBIDk4MjY0LCBVU0EiHRobChYKFAoSCU3x7aW1sIVUEU6VnlKhm7JsEgE3"
                     },
-                    "notes": "Mobile home park.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -1671,7 +1727,8 @@
                     },
                     "recipient": {
                         "name": "stop-4-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -1690,7 +1747,7 @@
                         "addressLineTwo": "stop-4-4 addressLineTwo",
                         "placeId": "EiwxMDAgUml2ZXJ2aWV3IFJkICMyMjcsIEx5bmRlbiwgV0EgOTgyNjQsIFVTQSIfGh0KFgoUChIJdaenOx23hVQR5rEFATlD7fsSAzIyNw"
                     },
-                    "notes": "Riverhouse Senior Apartments - Secure building. Please call recipient upon arrival. If you can't reach Ruth, it's ok to leave the box outside the building's covered front entrance (to the left, if you're facing the building).",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -1700,7 +1757,8 @@
                     },
                     "recipient": {
                         "name": "stop-4-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -1719,7 +1777,7 @@
                         "addressLineTwo": "stop-4-5 addressLineTwo",
                         "placeId": "ChIJLydXu_CkhVQR-x2BG-BG7XQ"
                     },
-                    "notes": "Please deliver to the chair by front door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -1729,7 +1787,8 @@
                     },
                     "recipient": {
                         "name": "stop-4-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -1748,7 +1807,7 @@
                         "addressLineTwo": "stop-4-6 addressLineTwo",
                         "placeId": "ChIJd4o-M-O5hVQRCUVy3ay2pCc"
                     },
-                    "notes": "House is at the end of a cul-de-sac.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 31,
                     "orderInfo": {
@@ -1758,7 +1817,8 @@
                     },
                     "recipient": {
                         "name": "stop-4-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/2e4BRZftJE6sVxX78LJ1",
                     "route": {
@@ -1784,7 +1844,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "ChIJl67NIJyhhVQRBw_8x7Cj8Mo"
                     },
-                    "notes": "Cresthaven Mobile Home Park - Refer to the park map at the entrance (at 41st & Samish Way) to find trailer. #32 is located on 40th St. Please deliver box to the chair by his door, do not leave on his steps.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -1794,7 +1854,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/4YO24cXYUXKblkB11Umv",
                     "route": {
@@ -1813,7 +1874,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -1821,7 +1882,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/4YO24cXYUXKblkB11Umv",
                     "route": {
@@ -1840,7 +1902,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "ChIJk8IxIxCkhVQR2m_w8LF-N-k"
                     },
-                    "notes": "Mill Wheel Park - Use the entrance closest to Decatur St. Recipient's trailer is up the hill, just past the 2nd set of mailboxes.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -1850,7 +1912,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/4YO24cXYUXKblkB11Umv",
                     "route": {
@@ -1869,7 +1932,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "ChIJWVp3DBinhVQRwTH-Wjd_R7c"
                     },
-                    "notes": "House is in Gate 5, fourth house on the left after turning into this gate. Has a red door and a ramp leading up to it.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -1879,7 +1942,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/4YO24cXYUXKblkB11Umv",
                     "route": {
@@ -1898,7 +1962,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -1906,7 +1970,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/4YO24cXYUXKblkB11Umv",
                     "route": {
@@ -1925,7 +1990,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "EjEyMTc0IFlldyBTdHJlZXQgUmQgIzIwLCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh4aHAoWChQKEgkV7bqlaKGFVBF6wf2ZBxGCrxICMjA"
                     },
-                    "notes": "Hilltop Haven Mobile Park - Recipient is in the last house on the left where the asphalt road turns to the right. The home is set back from the road and there is a post near the bushes displaying the unit number.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -1935,7 +2000,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/4YO24cXYUXKblkB11Umv",
                     "route": {
@@ -1954,7 +2020,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "ChIJzwPs4eamhVQRTLltLkxLaBw"
                     },
-                    "notes": "Downward driveway to a yellow/tan house.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -1964,7 +2030,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/4YO24cXYUXKblkB11Umv",
                     "route": {
@@ -1983,7 +2050,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "ChIJ04kuCammhVQRQCJMEmTZ_-U"
                     },
-                    "notes": "When looking at the house, front door is under the covered area on the right.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -1993,7 +2060,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/4YO24cXYUXKblkB11Umv",
                     "route": {
@@ -2012,7 +2080,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "ChIJy9Wa0RGkhVQRvMCA8lolCVs"
                     },
-                    "notes": "Mill Wheel Park - Use the entrance closest to Decatur St. Recipient's trailer is the first on the left side. Please deliver to the front door (on the EAST side of the trailer), the sliding door on the other porch is not functional.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -2022,7 +2090,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/4YO24cXYUXKblkB11Umv",
                     "route": {
@@ -2041,7 +2110,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "EjAyMjg0IFlldyBTdHJlZXQgUmQgYTksIEJlbGxpbmdoYW0sIFdBIDk4MjI5LCBVU0EiHhocChYKFAoSCXNW7_RnoYVUESlJOZ9AwJQLEgJhOQ"
                     },
-                    "notes": "Forest Park Mobile Home Park - Unit is located at the end of a driveway that is a steep gravel road, just before Forest Park Rd turns to the left. Probably safest to park near the small parking area at the top of the driveway and walk down with the box to deliver to porch. #A9 is directly across from #E1.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -2051,7 +2120,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/4YO24cXYUXKblkB11Umv",
                     "route": {
@@ -2075,7 +2145,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "ChIJI4S2rHihhVQRPoZ64V_5CbQ"
                     },
-                    "notes": "Recipient is in the red house. The entrance to the driveway is narrow and may be marked with a traffic cone.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -2085,7 +2155,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/4YO24cXYUXKblkB11Umv",
                     "route": {
@@ -2104,7 +2175,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "EjAyMjg0IFlldyBTdHJlZXQgUmQgZDQsIEJlbGxpbmdoYW0sIFdBIDk4MjI5LCBVU0EiHhocChYKFAoSCXNW7_RnoYVUESlJOZ9AwJQLEgJkNA"
                     },
-                    "notes": "Forest Park Mobile Home Park - Box can be placed behind the tarp with d-4 painted on it, on the truck of the car. It should be out of the rain here and within Lisa's reach.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -2114,7 +2185,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/4YO24cXYUXKblkB11Umv",
                     "route": {
@@ -2133,7 +2205,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "Ei00NzA5IFNhbWlzaCBXYXkgIzUsIEJlbGxpbmdoYW0sIFdBIDk4MjI5LCBVU0EiHRobChYKFAoSCXfG9l51oYVUEWb-_7BZZ6qmEgE1"
                     },
-                    "notes": "Lake Padden Apartments - Complex entrance is a gravel drive across from the Lake Padden West Entrance. Parking is limited. Recipient's unit is not marked with a number, it is the first door of the second complex (a blue structure).",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -2143,7 +2215,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/4YO24cXYUXKblkB11Umv",
                     "route": {
@@ -2162,7 +2235,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "ChIJSZfx9GehhVQR0auyp5DGzPY"
                     },
-                    "notes": "Forest Park Mobile Home Park - Follow Forest Park Rd all the way back and down the hill, #K2 will be on the left. Please deliver to front porch and knock on window.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -2172,7 +2245,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/4YO24cXYUXKblkB11Umv",
                     "route": {
@@ -2191,7 +2265,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "EjAxMDEgTiBTYW1pc2ggV2F5ICMxMzQsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHxodChYKFAoSCcNXsRTFo4VUEb2ow_3P-FnBEgMxMzQ"
                     },
-                    "notes": "Bellingham Lodge - Please deliver directly to room door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -2201,7 +2275,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/4YO24cXYUXKblkB11Umv",
                     "route": {
@@ -2220,7 +2295,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "Eis0NzI1IENhYmxlIFN0ICMyLCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh0aGwoWChQKEgnhgTQbHqSFVBHu1CeKhPnImxIBMg"
                     },
-                    "notes": "Yellow house, unit is on the second floor on the right side of the garage.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -2230,7 +2305,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/4YO24cXYUXKblkB11Umv",
                     "route": {
@@ -2256,7 +2332,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "EjAxODA1IEUgU3Vuc2V0IERyICMyMDIsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiHxodChYKFAoSCQdClqaHpIVUEZytg80TtN9dEgMyMDI"
                     },
-                    "notes": "LWC Sunset Apartment Complex",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -2266,7 +2342,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/4hNbLlPYYVnYrPoCBepp",
                     "route": {
@@ -2285,7 +2362,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "Ei4xNzA3IEUgU3Vuc2V0IERyICMyLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh0aGwoWChQKEgn3qCkPh6SFVBHo-4--8LT4oxIBMg"
                     },
-                    "notes": "Unit is on the bottom floor of 4-plex building. There are two recipients in this apartment, deliver both boxes to apartment door. This recipient requests that his box be marked with a  G  for George, if possible.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -2295,7 +2372,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/4hNbLlPYYVnYrPoCBepp",
                     "route": {
@@ -2314,7 +2392,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "Ei4xNzA3IEUgU3Vuc2V0IERyICMyLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh0aGwoWChQKEgn3qCkPh6SFVBHo-4--8LT4oxIBMg"
                     },
-                    "notes": "Unit is on the bottom floor of 4-plex building. There are two recipients in this apartment, deliver both boxes to apartment door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -2324,7 +2402,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/4hNbLlPYYVnYrPoCBepp",
                     "route": {
@@ -2343,7 +2422,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "Ei4zMTE1IFJhY2luZSBTdCAjMTE0LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgmPwvg3fqSFVBHiffqti7x9dhIDMTE0"
                     },
-                    "notes": "Barkley Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -2353,7 +2432,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/4hNbLlPYYVnYrPoCBepp",
                     "route": {
@@ -2372,7 +2452,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "EjAxODA1IEUgU3Vuc2V0IERyICMxMDMsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiHxodChYKFAoSCQdClqaHpIVUEZytg80TtN9dEgMxMDM"
                     },
-                    "notes": "LWC Sunset Apartment Complex",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -2382,7 +2462,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/4hNbLlPYYVnYrPoCBepp",
                     "route": {
@@ -2401,7 +2482,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -2409,7 +2490,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/4hNbLlPYYVnYrPoCBepp",
                     "route": {
@@ -2428,7 +2510,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "EjAxODAxIEUgU3Vuc2V0IERyICMyMDQsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiHxodChYKFAoSCTFDU66HpIVUEa36d_T4EI76EgMyMDQ"
                     },
-                    "notes": "Sunset Apartments - Please place box behind the black chair on the front porch.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -2438,7 +2520,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/4hNbLlPYYVnYrPoCBepp",
                     "route": {
@@ -2457,7 +2540,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "EjAxODAxIEUgU3Vuc2V0IERyICMyMDYsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiHxodChYKFAoSCTFDU66HpIVUEa36d_T4EI76EgMyMDY"
                     },
-                    "notes": "Sunset Apartments - Please CALL RECIPIENT when making the delivery. Boxes have been stolen several weeks in a row.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -2467,7 +2550,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/4hNbLlPYYVnYrPoCBepp",
                     "route": {
@@ -2486,7 +2570,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "EjAxODAxIEUgU3Vuc2V0IERyICMxMDUsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiHxodChYKFAoSCTFDU66HpIVUEa36d_T4EI76EgMxMDU"
                     },
-                    "notes": "Sunset Apartments - Every-other-week there are two recipients in this unit - Timothy and Susan. Please deliver both boxes (one for each) to the apartment door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -2496,7 +2580,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/4hNbLlPYYVnYrPoCBepp",
                     "route": {
@@ -2515,7 +2600,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "EjAxODAxIEUgU3Vuc2V0IERyICMxMDUsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiHxodChYKFAoSCTFDU66HpIVUEa36d_T4EI76EgMxMDU"
                     },
-                    "notes": "Sunset Apartments - Every-other-week there are two recipients in this unit - Timothy and Susan. Please deliver both boxes (one for each) to the apartment door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -2525,7 +2610,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/4hNbLlPYYVnYrPoCBepp",
                     "route": {
@@ -2549,7 +2635,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "EjAxODA1IEUgU3Vuc2V0IERyICMxMDQsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiHxodChYKFAoSCQdClqaHpIVUEZytg80TtN9dEgMxMDQ"
                     },
-                    "notes": "LWC Sunset Apartment Complex",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -2559,7 +2645,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/4hNbLlPYYVnYrPoCBepp",
                     "route": {
@@ -2578,7 +2665,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "ChIJwWY8poekhVQRLppoxP3nI8Q"
                     },
-                    "notes": "Lake Whatcom Center Sunset Apartments - Please deliver to the Lake Whatcom Center Heart House staff or next to bulding.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -2588,7 +2675,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/4hNbLlPYYVnYrPoCBepp",
                     "route": {
@@ -2607,7 +2695,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "EjAxODAzIEUgU3Vuc2V0IERyICMxMDEsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiHxodChYKFAoSCbvTbKOHpIVUEVJVAVWaKlkMEgMxMDE"
                     },
-                    "notes": "Sunset Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -2617,7 +2705,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/4hNbLlPYYVnYrPoCBepp",
                     "route": {
@@ -2636,7 +2725,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "EjAxODA1IEUgU3Vuc2V0IERyICMyMDEsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiHxodChYKFAoSCQdClqaHpIVUEZytg80TtN9dEgMyMDE"
                     },
-                    "notes": "LWC Sunset Apartment Complex",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -2646,7 +2735,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/4hNbLlPYYVnYrPoCBepp",
                     "route": {
@@ -2665,7 +2755,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "Ei4xNzExIEUgU3Vuc2V0IERyICMyLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh0aGwoWChQKEglZ41AGh6SFVBGjodAIFBnfqxIBMg"
                     },
-                    "notes": "Sunset Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -2675,7 +2765,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/4hNbLlPYYVnYrPoCBepp",
                     "route": {
@@ -2701,7 +2792,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "EjEzNDI4IFcgTWNMZW9kIFJkIGEgMTAyLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIiEaHwoWChQKEglh5YIOOqOFVBH8Z9fbiuiQAxIFYSAxMDI"
                     },
-                    "notes": "The Meadows Apartments - First building from road.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -2711,7 +2802,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/5zhvXRRYR69j00kXzAqz",
                     "route": {
@@ -2730,7 +2822,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "EjEzNDI4IFcgTWNMZW9kIFJkIGUgMTIxLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIiEaHwoWChQKEglh5YIOOqOFVBH8Z9fbiuiQAxIFZSAxMjE"
                     },
-                    "notes": "The Meadows Apartments - Furthest building from road.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -2740,7 +2832,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/5zhvXRRYR69j00kXzAqz",
                     "route": {
@@ -2759,7 +2852,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "EjAzNTA4IEFsZGVyd29vZCBBdmUgIzMsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHRobChYKFAoSCZnd08I6o4VUEZvZELt4Up0XEgEz"
                     },
-                    "notes": "Manufactured home, drive past trailer homes down driveway. IF THERE ARE SMALL DOGS THAT ARE IN YOUR PATH TO THE DOOR, PLEASE DO NOT COMPLETE THE DELIVERY. The dogs have been aggressive in the past. If this happens, call the HD Driver Support Line and we will speak with the recipient.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -2769,7 +2862,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/5zhvXRRYR69j00kXzAqz",
                     "route": {
@@ -2798,7 +2892,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/5zhvXRRYR69j00kXzAqz",
                     "route": {
@@ -2817,7 +2912,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "ChIJN4ZAeTyjhVQR2-47lZSkcEE"
                     },
-                    "notes": "Look for the grey two-story house.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -2827,7 +2922,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/5zhvXRRYR69j00kXzAqz",
                     "route": {
@@ -2846,7 +2942,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "EjAzNTA4IEFsZGVyd29vZCBBdmUgIzUsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHRobChYKFAoSCZnd08I6o4VUEZvZELt4Up0XEgE1"
                     },
-                    "notes": "Please leave on front yellow porch at yellow/green house. High risk residents.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -2856,7 +2952,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/5zhvXRRYR69j00kXzAqz",
                     "route": {
@@ -2875,7 +2972,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "Ei8zNDIwIFcgTWNMZW9kIFJkIGEgMSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJ86j0GzqjhVQR7SI5a8Gn1vESA2EgMQ"
                     },
-                    "notes": "Edgemont Apartments - Stairs above the office, left door",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -2885,7 +2982,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/5zhvXRRYR69j00kXzAqz",
                     "route": {
@@ -2904,7 +3002,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "EjAzNTI4IE5vcnRod2VzdCBBdmUgIzMsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHRobChYKFAoSCTdVew1Co4VUEfpPIeXyerWQEgEz"
                     },
-                    "notes": "Habitat Northwest Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -2914,7 +3012,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/5zhvXRRYR69j00kXzAqz",
                     "route": {
@@ -2933,7 +3032,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "EjAzNDIwIFcgTWNMZW9kIFJkIGkgODMsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiIBoeChYKFAoSCfOo9Bs6o4VUEe0iOWvBp9bxEgRpIDgz"
                     },
-                    "notes": "Edgemont Apartments - If you need assistance and recipient is not answering, please call alternative phone number - 360-325-6553.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -2943,7 +3042,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/5zhvXRRYR69j00kXzAqz",
                     "route": {
@@ -2962,7 +3062,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "EjAzNDIwIFcgTWNMZW9kIFJkIGkgNzksIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiIBoeChYKFAoSCfOo9Bs6o4VUEe0iOWvBp9bxEgRpIDc5"
                     },
-                    "notes": "Edgemont Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -2972,7 +3072,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/5zhvXRRYR69j00kXzAqz",
                     "route": {
@@ -2996,7 +3097,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -3004,7 +3105,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/5zhvXRRYR69j00kXzAqz",
                     "route": {
@@ -3023,7 +3125,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "EjAzNDIwIFcgTWNMZW9kIFJkIGcgNjMsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiIBoeChYKFAoSCfOo9Bs6o4VUEe0iOWvBp9bxEgRnIDYz"
                     },
-                    "notes": "Edgemont Apartments - Recipient's unit is in the second to last building on the right-hand side.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -3033,7 +3135,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/5zhvXRRYR69j00kXzAqz",
                     "route": {
@@ -3052,7 +3155,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "EjAzNTA4IEFsZGVyd29vZCBBdmUgIzEsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHRobChYKFAoSCZnd08I6o4VUEZvZELt4Up0XEgEx"
                     },
-                    "notes": "Recipient lives in the front trailer.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -3062,7 +3165,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/5zhvXRRYR69j00kXzAqz",
                     "route": {
@@ -3081,7 +3185,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "EjIzNzgwIENhbnRlcmJ1cnkgTG4gIzE0OSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJ_1b8lDmjhVQRJzV7YqsT31wSAzE0OQ"
                     },
-                    "notes": "Canterbury Court Apartments - Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -3091,7 +3195,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/5zhvXRRYR69j00kXzAqz",
                     "route": {
@@ -3110,7 +3215,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "ChIJP1UckkejhVQRiwVBiMKwew4"
                     },
-                    "notes": "There is a makeshift step that is crooked and wobbly, please use caution and avoid it if you can.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -3120,7 +3225,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/5zhvXRRYR69j00kXzAqz",
                     "route": {
@@ -3139,7 +3245,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "EjAzNTIwIE5vcnRod2VzdCBBdmUgIzUsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHRobChYKFAoSCdsisQ5Co4VUEdTr7Oz0-wqkEgE1"
                     },
-                    "notes": "Habitat Northwest - Habitat has two addresses- 3520(Anita's building) and 3528, please be sure you are delivering to the correct building.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -3149,7 +3255,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/5zhvXRRYR69j00kXzAqz",
                     "route": {
@@ -3175,7 +3282,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "EjI5ODggUGFjaWZpYyBSaW0gTG4gIzEwMSwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJ2YLselW7hVQRoZek0JvhZagSAzEwMQ"
                     },
-                    "notes": "Pacific Rim Apartments - Knock loudly",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -3185,7 +3292,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/7NNa7aQ1r9wS0n4dpxws",
                     "route": {
@@ -3204,7 +3312,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "EjI0MDE0IE5vcnRod2VzdCBBdmUgIzMwOCwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJe6Rp3kSjhVQRVeWPHpw8qTASAzMwOA"
                     },
-                    "notes": "Belleau Woods Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -3214,7 +3322,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/7NNa7aQ1r9wS0n4dpxws",
                     "route": {
@@ -3233,7 +3342,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "ChIJXz3AZFCjhVQRnpaOf_MJH-o"
                     },
-                    "notes": "Home is at the end of the street on the righthand side, immediately after the  no outlet  street sign.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -3243,7 +3352,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/7NNa7aQ1r9wS0n4dpxws",
                     "route": {
@@ -3262,7 +3372,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "EjI5ODggUGFjaWZpYyBSaW0gTG4gIzEwMCwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJ2YLselW7hVQRoZek0JvhZagSAzEwMA"
                     },
-                    "notes": "Pacific Rim Apartments - Recipient's unit is upstairs.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -3272,7 +3382,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/7NNa7aQ1r9wS0n4dpxws",
                     "route": {
@@ -3291,7 +3402,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "Eis1ODQ2IFBhY2lmaWMgUmltIENvdXJ0LCBCZWxsaW5naGFtLCBXQSwgVVNBIjESLwoUChIJmQuQdlW7hVQR7qJoVgt_DlUQ1i0qFAoSCZkLkHZVu4VUEVqR_CYhv0K7"
                     },
-                    "notes": "Pacific Rim Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -3301,7 +3412,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/7NNa7aQ1r9wS0n4dpxws",
                     "route": {
@@ -3320,7 +3432,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "EjExMzAwIE1haG9nYW55IEF2ZSAjMjExLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgmL14YiTKOFVBFMpBOBturs2BIDMjEx"
                     },
-                    "notes": "Mahogany Manor - Secured building. Keypad is located by the door under the  Mahogany Manor  sign. Look for Melissa Rugg on the keypad and she will buzz you in. Call Melissa if you can't get the keypad to work.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -3330,7 +3442,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/7NNa7aQ1r9wS0n4dpxws",
                     "route": {
@@ -3349,7 +3462,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "EjM1ODE2IFBhY2lmaWMgUmltIFdheSAjMTgsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiHhocChYKFAoSCfNTHxNVu4VUEYxySxzl7CdaEgIxOA"
                     },
-                    "notes": "Pacific Rim Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -3359,7 +3472,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/7NNa7aQ1r9wS0n4dpxws",
                     "route": {
@@ -3378,7 +3492,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "EjE5NzkgUGFjaWZpYyBSaW0gTG4gIzgzLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh4aHAoWChQKEgm1rNJxVbuFVBHrJPiKW-ZaaxICODM"
                     },
-                    "notes": "Pacific Rim Apartments - Deliver next to door mat.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -3388,7 +3502,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/7NNa7aQ1r9wS0n4dpxws",
                     "route": {
@@ -3407,7 +3522,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "ChIJ23cZ906jhVQRIvhhhDjYI7c"
                     },
-                    "notes": "Deliver next to chairs on deck.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -3417,7 +3532,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/7NNa7aQ1r9wS0n4dpxws",
                     "route": {
@@ -3436,7 +3552,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "EjM1ODA2IFBhY2lmaWMgUmltIFdheSAjMTAsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiHhocChYKFAoSCalCSRNVu4VUEY2cZzPDuFOyEgIxMA"
                     },
-                    "notes": "Pacific Rim Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -3446,7 +3562,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/7NNa7aQ1r9wS0n4dpxws",
                     "route": {
@@ -3470,7 +3587,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -3478,7 +3595,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/7NNa7aQ1r9wS0n4dpxws",
                     "route": {
@@ -3497,7 +3615,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "EjExMzAwIE1haG9nYW55IEF2ZSAjMjM3LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgmL14YiTKOFVBFMpBOBturs2BIDMjM3"
                     },
-                    "notes": "Mahogany Manor - Secured building. Keypad is located by the door under the  Mahogany Manor  sign. Have to push the  Enter  button on the pad to pull up the numbers, then dial 1359 to open the door. Recipient is Ukrainian-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -3507,7 +3625,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/7NNa7aQ1r9wS0n4dpxws",
                     "route": {
@@ -3526,7 +3645,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "EjI1ODA2IFBhY2lmaWMgUmltIFdheSAjNiwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIdGhsKFgoUChIJqUJJE1W7hVQRjZxnM8O4U7ISATY"
                     },
-                    "notes": "Pacific Rim Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -3536,7 +3655,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/7NNa7aQ1r9wS0n4dpxws",
                     "route": {
@@ -3562,7 +3682,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "Ei8yMDYgRSBMYXVyZWwgU3QgIzQwNSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJHc_qvbmjhVQRPA8jxuatwtESAzQwNQ"
                     },
-                    "notes": "Laurel Village*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -3572,7 +3692,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -3591,7 +3712,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "Ei8yMDYgRSBMYXVyZWwgU3QgIzEwMSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJHc_qvbmjhVQRPA8jxuatwtESAzEwMQ"
                     },
-                    "notes": "Laurel Village* - Recipient's unit is directly above the garage, please take the ramp leading above garage and deliver to apartment door. Call recipient's phone if you need help.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -3601,7 +3722,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -3620,7 +3742,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "EjAxMDAwIE4gRm9yZXN0IFN0ICM0MTYsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHxodChYKFAoSCQlI0Fa4o4VUEYkyCXMeKgS0EgM0MTY"
                     },
-                    "notes": "Laurel Forest Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 22,
                     "orderInfo": {
@@ -3630,7 +3752,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -3649,7 +3772,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "Ei8xMDAgVyBMYXVyZWwgU3QgIzMxNSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJX14zybujhVQRye39xwnFeVoSAzMxNQ"
                     },
-                    "notes": "The Millworks - Must call recipient upon arrival. Door code is confidential.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 34,
                     "orderInfo": {
@@ -3659,7 +3782,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -3678,7 +3802,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "EjAxMDAwIE4gRm9yZXN0IFN0ICMzMTIsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHxodChYKFAoSCQlI0Fa4o4VUEYkyCXMeKgS0EgMzMTI"
                     },
-                    "notes": "Laurel Forest Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 21,
                     "orderInfo": {
@@ -3688,7 +3812,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -3707,7 +3832,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "Ei8yMDQgRSBMYXVyZWwgU3QgIzEwNSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJ-6QWv7mjhVQRpc8HQG9EB2QSAzEwNQ"
                     },
-                    "notes": "Laurel Village* - This recipient prefers that her box be delivered to the ground floor entrance, accessed from the sidewalk/grassed area.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -3717,7 +3842,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -3736,7 +3862,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "EjAxNTEwIE4gRm9yZXN0IFN0ICMxMDEsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHxodChYKFAoSCTk-9Aa-o4VUEfR8VgQv4z4DEgMxMDE"
                     },
-                    "notes": "Eleanor Apartments* - gate code is #101",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -3746,7 +3872,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -3765,7 +3892,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "EjAxNTEwIE4gRm9yZXN0IFN0ICMzMDksIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHxodChYKFAoSCTk-9Aa-o4VUEfR8VgQv4z4DEgMzMDk"
                     },
-                    "notes": "Eleanor Apartments* - gate code is #309",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -3775,7 +3902,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -3794,7 +3922,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "EjAxNTEwIE4gRm9yZXN0IFN0ICM0MTIsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHxodChYKFAoSCTk-9Aa-o4VUEfR8VgQv4z4DEgM0MTI"
                     },
-                    "notes": "Eleanor Apartments* - gate code is #412",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -3804,7 +3932,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -3823,7 +3952,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "EjExMTMzIFJhaWxyb2FkIEF2ZSAjMjE1LCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgnFSivju6OFVBHoU-Kr_18lkhIDMjE1"
                     },
-                    "notes": "Washington Grocery Building*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 28,
                     "orderInfo": {
@@ -3833,7 +3962,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -3857,7 +3987,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "EjExMTMzIFJhaWxyb2FkIEF2ZSAjMjA2LCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgnFSivju6OFVBHoU-Kr_18lkhIDMjA2"
                     },
-                    "notes": "Washington Grocery Building*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 27,
                     "orderInfo": {
@@ -3867,7 +3997,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -3886,7 +4017,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "Ei8xMDAgVyBMYXVyZWwgU3QgIzIyMywgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJX14zybujhVQRye39xwnFeVoSAzIyMw"
                     },
-                    "notes": "The Millworks - Must call recipient upon arrival. Door code is confidential.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 33,
                     "orderInfo": {
@@ -3896,7 +4027,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -3915,7 +4047,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "EjAxMDAwIE4gRm9yZXN0IFN0ICMyMTAsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHxodChYKFAoSCQlI0Fa4o4VUEYkyCXMeKgS0EgMyMTA"
                     },
-                    "notes": "Laurel Forest Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 20,
                     "orderInfo": {
@@ -3925,7 +4057,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -3944,7 +4077,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "EjExMTMzIFJhaWxyb2FkIEF2ZSAjMzEwLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgnFSivju6OFVBHoU-Kr_18lkhIDMzEw"
                     },
-                    "notes": "Washington Grocery Building*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 26,
                     "orderInfo": {
@@ -3954,7 +4087,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -3973,7 +4107,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "Ei8yMDIgRSBMYXVyZWwgU3QgIzIwNCwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJC6axxrmjhVQR9hNymKXdVdgSAzIwNA"
                     },
-                    "notes": "Laurel Village*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -3983,7 +4117,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -4002,7 +4137,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "Ei8xMDAgVyBMYXVyZWwgU3QgIzMwMiwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJX14zybujhVQRye39xwnFeVoSAzMwMg"
                     },
-                    "notes": "The Millworks - Must call recipient upon arrival. Door code is confidential.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 32,
                     "orderInfo": {
@@ -4012,7 +4147,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -4031,7 +4167,7 @@
                         "addressLineTwo": "stop-1-6 addressLineTwo",
                         "placeId": "Ei8xMDAgVyBMYXVyZWwgU3QgIzMyNCwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJX14zybujhVQRye39xwnFeVoSAzMyNA"
                     },
-                    "notes": "The Millworks - Must call/text recipient upon arrival. Door code is confidential. Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 31,
                     "orderInfo": {
@@ -4041,7 +4177,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -4060,7 +4197,7 @@
                         "addressLineTwo": "stop-1-7 addressLineTwo",
                         "placeId": "Ei8yMDIgRSBMYXVyZWwgU3QgIzIwMywgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJC6axxrmjhVQR9hNymKXdVdgSAzIwMw"
                     },
-                    "notes": "Laurel Village*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -4070,7 +4207,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -4089,7 +4227,7 @@
                         "addressLineTwo": "stop-1-8 addressLineTwo",
                         "placeId": "Ei8xMDAgVyBMYXVyZWwgU3QgIzMyMSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJX14zybujhVQRye39xwnFeVoSAzMyMQ"
                     },
-                    "notes": "The Millworks - Must call recipient upon arrival. Door code is confidential.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 30,
                     "orderInfo": {
@@ -4099,7 +4237,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -4118,7 +4257,7 @@
                         "addressLineTwo": "stop-1-9 addressLineTwo",
                         "placeId": "EjAxMDAwIE4gRm9yZXN0IFN0ICMyMTMsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHxodChYKFAoSCQlI0Fa4o4VUEYkyCXMeKgS0EgMyMTM"
                     },
-                    "notes": "Laurel Forest Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 19,
                     "orderInfo": {
@@ -4128,7 +4267,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -4152,7 +4292,7 @@
                         "addressLineTwo": "stop-2-0 addressLineTwo",
                         "placeId": "EjAxMDAwIE4gRm9yZXN0IFN0ICMyMTEsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHxodChYKFAoSCQlI0Fa4o4VUEYkyCXMeKgS0EgMyMTE"
                     },
-                    "notes": "Laurel Forest Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 18,
                     "orderInfo": {
@@ -4162,7 +4302,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -4181,7 +4322,7 @@
                         "addressLineTwo": "stop-2-1 addressLineTwo",
                         "placeId": "EjExMTMzIFJhaWxyb2FkIEF2ZSAjMzA2LCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgnFSivju6OFVBHoU-Kr_18lkhIDMzA2"
                     },
-                    "notes": "Washington Grocery Building* - Use the call box to call the recipient (press # and then the apartment number) and they will meet you in the lobby.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 25,
                     "orderInfo": {
@@ -4191,7 +4332,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -4210,7 +4352,7 @@
                         "addressLineTwo": "stop-2-2 addressLineTwo",
                         "placeId": "Ei8yMDIgRSBMYXVyZWwgU3QgIzEwNiwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJC6axxrmjhVQR9hNymKXdVdgSAzEwNg"
                     },
-                    "notes": "Laurel Village*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -4220,7 +4362,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -4239,7 +4382,7 @@
                         "addressLineTwo": "stop-2-3 addressLineTwo",
                         "placeId": "Ei8yMDQgRSBMYXVyZWwgU3QgIzEwMywgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJ-6QWv7mjhVQRpc8HQG9EB2QSAzEwMw"
                     },
-                    "notes": "Laurel Village*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -4249,7 +4392,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -4268,7 +4412,7 @@
                         "addressLineTwo": "stop-2-4 addressLineTwo",
                         "placeId": "EjAxNTEwIE4gRm9yZXN0IFN0ICM0MjMsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHxodChYKFAoSCTk-9Aa-o4VUEfR8VgQv4z4DEgM0MjM"
                     },
-                    "notes": "Eleanor Apartments* - gate code is #423",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -4278,7 +4422,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -4297,7 +4442,7 @@
                         "addressLineTwo": "stop-2-5 addressLineTwo",
                         "placeId": "EjAxNTEwIE4gRm9yZXN0IFN0ICMzMjIsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHxodChYKFAoSCTk-9Aa-o4VUEfR8VgQv4z4DEgMzMjI"
                     },
-                    "notes": "Eleanor Apartments* - gate code is #322",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -4307,7 +4452,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -4326,7 +4472,7 @@
                         "addressLineTwo": "stop-2-6 addressLineTwo",
                         "placeId": "EjAxMDAwIE4gRm9yZXN0IFN0ICMyMDUsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHxodChYKFAoSCQlI0Fa4o4VUEYkyCXMeKgS0EgMyMDU"
                     },
-                    "notes": "Laurel Forest Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 17,
                     "orderInfo": {
@@ -4336,7 +4482,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -4355,7 +4502,7 @@
                         "addressLineTwo": "stop-2-7 addressLineTwo",
                         "placeId": "EjAxNTEwIE4gRm9yZXN0IFN0ICM0MTgsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHxodChYKFAoSCTk-9Aa-o4VUEfR8VgQv4z4DEgM0MTg"
                     },
-                    "notes": "Eleanor Apartments* - gate code is #418",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -4365,7 +4512,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -4384,7 +4532,7 @@
                         "addressLineTwo": "stop-2-8 addressLineTwo",
                         "placeId": "EjExMTMzIFJhaWxyb2FkIEF2ZSAjMzA5LCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgnFSivju6OFVBHoU-Kr_18lkhIDMzA5"
                     },
-                    "notes": "Washington Grocery Building* - Use the call box to call the recipient (press # and then the apartment number) and they will meet you in the lobby.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 24,
                     "orderInfo": {
@@ -4394,7 +4542,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -4413,7 +4562,7 @@
                         "addressLineTwo": "stop-2-9 addressLineTwo",
                         "placeId": "EjAxMDAwIE4gRm9yZXN0IFN0ICMzMDcsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHxodChYKFAoSCQlI0Fa4o4VUEYkyCXMeKgS0EgMzMDc"
                     },
-                    "notes": "Laurel Forest Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 16,
                     "orderInfo": {
@@ -4423,7 +4572,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -4447,7 +4597,7 @@
                         "addressLineTwo": "stop-3-0 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -4455,7 +4605,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -4474,7 +4625,7 @@
                         "addressLineTwo": "stop-3-1 addressLineTwo",
                         "placeId": "EjAxNTEwIE4gRm9yZXN0IFN0ICMyMDcsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHxodChYKFAoSCTk-9Aa-o4VUEfR8VgQv4z4DEgMyMDc"
                     },
-                    "notes": "Eleanor Apartments* - gate code is #207",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -4484,7 +4635,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -4503,7 +4655,7 @@
                         "addressLineTwo": "stop-3-2 addressLineTwo",
                         "placeId": "EjAxNTEwIE4gRm9yZXN0IFN0ICMyMTksIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHxodChYKFAoSCTk-9Aa-o4VUEfR8VgQv4z4DEgMyMTk"
                     },
-                    "notes": "Eleanor Apartments* - gate code is #219",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -4513,7 +4665,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -4532,7 +4685,7 @@
                         "addressLineTwo": "stop-3-3 addressLineTwo",
                         "placeId": "EjExMTMzIFJhaWxyb2FkIEF2ZSAjMjE0LCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgnFSivju6OFVBHoU-Kr_18lkhIDMjE0"
                     },
-                    "notes": "Washington Grocery Building*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 23,
                     "orderInfo": {
@@ -4542,7 +4695,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -4561,7 +4715,7 @@
                         "addressLineTwo": "stop-3-4 addressLineTwo",
                         "placeId": "Ei8xMDAgVyBMYXVyZWwgU3QgIzMxMSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJX14zybujhVQRye39xwnFeVoSAzMxMQ"
                     },
-                    "notes": "The Millworks - Must call recipient upon arrival. Door code is confidential.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 29,
                     "orderInfo": {
@@ -4571,7 +4725,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/8ZCMgGsWGv1yomDCA9yX",
                     "route": {
@@ -4597,7 +4752,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "Ei4zMjI3IFJhY2luZSBTdCAjMTAxLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgmnNaetgKSFVBFFgJjEEkQx7RIDMTAx"
                     },
-                    "notes": "Barkley Ridge Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -4607,7 +4762,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/8p4qEQFyIg5hw2siHQgo",
                     "route": {
@@ -4626,7 +4782,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "Ei4zMjE1IFJhY2luZSBTdCAjMjAxLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgnnurWugKSFVBEeC_WNYzUtbhIDMjAx"
                     },
-                    "notes": "Barkley Ridge Apartments. ***Let Sierra know if there is unused food outside Lindy's door***",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -4636,7 +4792,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/8p4qEQFyIg5hw2siHQgo",
                     "route": {
@@ -4655,7 +4812,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "Ei4zMTk5IFJhY2luZSBTdCAjMjA0LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgm9ZrK6gKSFVBHdI9uZHAfukhIDMjA0"
                     },
-                    "notes": "Barkley Ridge Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -4665,7 +4822,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/8p4qEQFyIg5hw2siHQgo",
                     "route": {
@@ -4684,7 +4842,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "Ei4zMTk5IFJhY2luZSBTdCAjMTA1LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgm9ZrK6gKSFVBHdI9uZHAfukhIDMTA1"
                     },
-                    "notes": "Barkley Ridge Apartments - Next door and to the west of the 3219 Racine buidling.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -4694,7 +4852,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/8p4qEQFyIg5hw2siHQgo",
                     "route": {
@@ -4713,7 +4872,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "Ei4zMjE5IFJhY2luZSBTdCAjMTAyLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEglfA4EbY6WFVBHcgYHNJtsbjxIDMTAy"
                     },
-                    "notes": "Barkley Ridge Apartments - Last right on Racine St, another right at end of parking lot. Building is north of the smoking area. Apartment is on the first floor.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -4723,7 +4882,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/8p4qEQFyIg5hw2siHQgo",
                     "route": {
@@ -4742,7 +4902,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "Ei4zMjE5IFJhY2luZSBTdCAjMTAzLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEglfA4EbY6WFVBHcgYHNJtsbjxIDMTAz"
                     },
-                    "notes": "Barkley Ridge Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -4752,7 +4912,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/8p4qEQFyIg5hw2siHQgo",
                     "route": {
@@ -4771,7 +4932,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "Ei4zMTk1IFJhY2luZSBTdCAjMTA0LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgm9ZrK6gKSFVBE_caQjZT4DLRIDMTA0"
                     },
-                    "notes": "Barkley Ridge Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -4781,7 +4942,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/8p4qEQFyIg5hw2siHQgo",
                     "route": {
@@ -4800,7 +4962,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "Ei4zMTk1IFJhY2luZSBTdCAjMjA1LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgm9ZrK6gKSFVBE_caQjZT4DLRIDMjA1"
                     },
-                    "notes": "Barkley Ridge Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 16,
                     "orderInfo": {
@@ -4810,7 +4972,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/8p4qEQFyIg5hw2siHQgo",
                     "route": {
@@ -4829,7 +4992,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "Ei4zMjE1IFJhY2luZSBTdCAjMjA0LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgnnurWugKSFVBEeC_WNYzUtbhIDMjA0"
                     },
-                    "notes": "Barkley Ridge Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -4839,7 +5002,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/8p4qEQFyIg5hw2siHQgo",
                     "route": {
@@ -4858,7 +5022,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "Ei4zMTk5IFJhY2luZSBTdCAjMTA2LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgm9ZrK6gKSFVBHdI9uZHAfukhIDMTA2"
                     },
-                    "notes": "Barkley Ridge Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -4868,7 +5032,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/8p4qEQFyIg5hw2siHQgo",
                     "route": {
@@ -4892,7 +5057,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "Ei4zMjE1IFJhY2luZSBTdCAjMTAzLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgnnurWugKSFVBEeC_WNYzUtbhIDMTAz"
                     },
-                    "notes": "Barkley Ridge Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -4902,7 +5067,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/8p4qEQFyIg5hw2siHQgo",
                     "route": {
@@ -4921,7 +5087,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "Ei4zMTk1IFJhY2luZSBTdCAjMTA1LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgm9ZrK6gKSFVBE_caQjZT4DLRIDMTA1"
                     },
-                    "notes": "Barkley Ridge Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -4931,7 +5097,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/8p4qEQFyIg5hw2siHQgo",
                     "route": {
@@ -4950,7 +5117,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "Ei4zMTk5IFJhY2luZSBTdCAjMTA0LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgm9ZrK6gKSFVBHdI9uZHAfukhIDMTA0"
                     },
-                    "notes": "Barkley Ridge Apartments - Next door and to the west of the 3219 Racine buidling.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -4960,7 +5127,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/8p4qEQFyIg5hw2siHQgo",
                     "route": {
@@ -4979,7 +5147,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "ChIJuyrC0NWlhVQRM60K8sOahEc"
                     },
-                    "notes": "Barkley Ridge Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -4989,7 +5157,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/8p4qEQFyIg5hw2siHQgo",
                     "route": {
@@ -5008,7 +5177,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "Ei4zMTk5IFJhY2luZSBTdCAjMTAyLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgm9ZrK6gKSFVBHdI9uZHAfukhIDMTAy"
                     },
-                    "notes": "Barkley Ridge Apartments - Next door and to the west of the 3219 Racine buidling.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -5018,7 +5187,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/8p4qEQFyIg5hw2siHQgo",
                     "route": {
@@ -5037,7 +5207,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "Ei4zMTk1IFJhY2luZSBTdCAjMjA2LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgm9ZrK6gKSFVBE_caQjZT4DLRIDMjA2"
                     },
-                    "notes": "Barkley Ridge Apartments - Recipient is on 2nd floor. Phone number provided is for case worker",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -5047,7 +5217,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/8p4qEQFyIg5hw2siHQgo",
                     "route": {
@@ -5066,7 +5237,7 @@
                         "addressLineTwo": "stop-1-6 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -5074,7 +5245,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/8p4qEQFyIg5hw2siHQgo",
                     "route": {
@@ -5100,7 +5272,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "Ei4yMDEwIEZyYXNlciBTdCAjMTA2LCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEglJ7J3h8qOFVBHNA7F1GpfmthIDMTA2"
                     },
-                    "notes": "Regency Park Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 19,
                     "orderInfo": {
@@ -5110,7 +5282,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/AqcSgl1s1MDonjzYBHM2",
                     "route": {
@@ -5129,7 +5302,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "Ei4yMDU1IEZyYXNlciBTdCAjMTAyLCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEgnJo8Qt86OFVBFQVaZGz3PkmBIDMTAy"
                     },
-                    "notes": "Regency Park Apartments* - The 2055 building is located on the north side of Fraser.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 20,
                     "orderInfo": {
@@ -5139,7 +5312,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/AqcSgl1s1MDonjzYBHM2",
                     "route": {
@@ -5158,7 +5332,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "Ei4xOTYwIEZyYXNlciBTdCAjMzAyLCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEgklsZva8qOFVBE1S6z7RuNTmxIDMzAy"
                     },
-                    "notes": "Regency Park Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -5168,7 +5342,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/AqcSgl1s1MDonjzYBHM2",
                     "route": {
@@ -5187,7 +5362,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "Ei4xOTgwIEZyYXNlciBTdCAjMTAxLCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEgn9AQ_y8qOFVBFciuOCZ_KC2hIDMTAx"
                     },
-                    "notes": "Regency Park Apartments* - Please DO NOT deliver to glass door on porch, intead walk around to the main door at breezeway.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 26,
                     "orderInfo": {
@@ -5197,7 +5372,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/AqcSgl1s1MDonjzYBHM2",
                     "route": {
@@ -5216,7 +5392,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "Ei4xOTkwIEZyYXNlciBTdCAjMjA2LCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEgm3F9EX86OFVBEdCOwB5cSLFBIDMjA2"
                     },
-                    "notes": "Regency Park Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -5226,7 +5402,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/AqcSgl1s1MDonjzYBHM2",
                     "route": {
@@ -5245,7 +5422,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "Ei4xOTgwIEZyYXNlciBTdCAjMzAxLCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEgn9AQ_y8qOFVBFciuOCZ_KC2hIDMzAx"
                     },
-                    "notes": "Regency Park Apartments* - Please tell Sierra if there is unused food outside the door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 24,
                     "orderInfo": {
@@ -5255,7 +5432,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/AqcSgl1s1MDonjzYBHM2",
                     "route": {
@@ -5274,7 +5452,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "Ei4xOTkwIEZyYXNlciBTdCAjMjA0LCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEgm3F9EX86OFVBEdCOwB5cSLFBIDMjA0"
                     },
-                    "notes": "Regency Park Apartments* - KNOCK LOUD",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -5284,7 +5462,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/AqcSgl1s1MDonjzYBHM2",
                     "route": {
@@ -5303,7 +5482,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "Ei4yMDEwIEZyYXNlciBTdCAjMzA4LCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEglJ7J3h8qOFVBHNA7F1GpfmthIDMzA4"
                     },
-                    "notes": "Regency Park Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 18,
                     "orderInfo": {
@@ -5313,7 +5492,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/AqcSgl1s1MDonjzYBHM2",
                     "route": {
@@ -5332,7 +5512,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "Ei4yMDU1IEZyYXNlciBTdCAjMjA3LCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEgnJo8Qt86OFVBFQVaZGz3PkmBIDMjA3"
                     },
-                    "notes": "Regency Park Apartments* - The 2055 building is located on the north side of Fraser.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 22,
                     "orderInfo": {
@@ -5342,7 +5522,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/AqcSgl1s1MDonjzYBHM2",
                     "route": {
@@ -5361,7 +5542,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "Ei4xOTkwIEZyYXNlciBTdCAjMTA3LCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEgm3F9EX86OFVBEdCOwB5cSLFBIDMTA3"
                     },
-                    "notes": "Regency Park Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -5371,7 +5552,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/AqcSgl1s1MDonjzYBHM2",
                     "route": {
@@ -5395,7 +5577,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "Ei4xOTgwIEZyYXNlciBTdCAjMjAzLCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEgn9AQ_y8qOFVBFciuOCZ_KC2hIDMjAz"
                     },
-                    "notes": "Regency Park Apartments* - Please tell Sierra if there is unused food outside the door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 25,
                     "orderInfo": {
@@ -5405,7 +5587,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/AqcSgl1s1MDonjzYBHM2",
                     "route": {
@@ -5424,7 +5607,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "Ei4xOTUwIEZyYXNlciBTdCAjMjA4LCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEglTMgnU8qOFVBFw8CEtCoGLfhIDMjA4"
                     },
-                    "notes": "Regency Park Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -5434,7 +5617,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/AqcSgl1s1MDonjzYBHM2",
                     "route": {
@@ -5453,7 +5637,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "Ei4xOTcwIEZyYXNlciBTdCAjMzAzLCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEgkpVK7D8qOFVBF3a7irpZ9aIRIDMzAz"
                     },
-                    "notes": "Regency Park Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -5463,7 +5647,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/AqcSgl1s1MDonjzYBHM2",
                     "route": {
@@ -5482,7 +5667,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "Ei4yMDAwIEZyYXNlciBTdCAjMTAxLCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEgmF3lH78qOFVBE5By3RRc0VWxIDMTAx"
                     },
-                    "notes": "Regency Park Apartments* - Use the Ring doorbell",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -5492,7 +5677,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/AqcSgl1s1MDonjzYBHM2",
                     "route": {
@@ -5511,7 +5697,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "Ei4yMDU1IEZyYXNlciBTdCAjMjA4LCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEgnJo8Qt86OFVBFQVaZGz3PkmBIDMjA4"
                     },
-                    "notes": "Regency Park Apartments* - The 2055 building is located on the north side of Fraser.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 23,
                     "orderInfo": {
@@ -5521,7 +5707,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/AqcSgl1s1MDonjzYBHM2",
                     "route": {
@@ -5540,7 +5727,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "Ei4yMDAwIEZyYXNlciBTdCAjMTAzLCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEgmF3lH78qOFVBE5By3RRc0VWxIDMTAz"
                     },
-                    "notes": "Regency Park Apartments* - Use the Ring doorbell.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 16,
                     "orderInfo": {
@@ -5550,7 +5737,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/AqcSgl1s1MDonjzYBHM2",
                     "route": {
@@ -5569,7 +5757,7 @@
                         "addressLineTwo": "stop-1-6 addressLineTwo",
                         "placeId": "Ei4yMDMwIEZyYXNlciBTdCAjMjAyLCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEglhbRne8qOFVBFSCCD1RcpNeBIDMjAy"
                     },
-                    "notes": "Regency Park Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -5579,7 +5767,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/AqcSgl1s1MDonjzYBHM2",
                     "route": {
@@ -5598,7 +5787,7 @@
                         "addressLineTwo": "stop-1-7 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -5606,7 +5795,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/AqcSgl1s1MDonjzYBHM2",
                     "route": {
@@ -5625,7 +5815,7 @@
                         "addressLineTwo": "stop-1-8 addressLineTwo",
                         "placeId": "Ei4yMDMwIEZyYXNlciBTdCAjMzAyLCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEglhbRne8qOFVBFSCCD1RcpNeBIDMzAy"
                     },
-                    "notes": "Regency Park Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -5635,7 +5825,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/AqcSgl1s1MDonjzYBHM2",
                     "route": {
@@ -5654,7 +5845,7 @@
                         "addressLineTwo": "stop-1-9 addressLineTwo",
                         "placeId": "Ei4yMDEwIEZyYXNlciBTdCAjMTA3LCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEglJ7J3h8qOFVBHNA7F1GpfmthIDMTA3"
                     },
-                    "notes": "Regency Park Apartments* - Please ring doorbell.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 17,
                     "orderInfo": {
@@ -5664,7 +5855,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/AqcSgl1s1MDonjzYBHM2",
                     "route": {
@@ -5688,7 +5880,7 @@
                         "addressLineTwo": "stop-2-0 addressLineTwo",
                         "placeId": "Ei4xOTkwIEZyYXNlciBTdCAjMjA1LCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEgm3F9EX86OFVBEdCOwB5cSLFBIDMjA1"
                     },
-                    "notes": "Regency Park Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -5698,7 +5890,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/AqcSgl1s1MDonjzYBHM2",
                     "route": {
@@ -5717,7 +5910,7 @@
                         "addressLineTwo": "stop-2-1 addressLineTwo",
                         "placeId": "ChIJ_TbrzuWjhVQRNIW6NLiQdlA"
                     },
-                    "notes": "Regency Park Apartments* - The 2055 building is located on the north side of Fraser. RECIPIENT IS SENSITIVE TO LOUD SOUNDS, PLEASE DO NOT KNOCK WHEN MAKING A DELIVERY.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -5727,7 +5920,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/AqcSgl1s1MDonjzYBHM2",
                     "route": {
@@ -5746,7 +5940,7 @@
                         "addressLineTwo": "stop-2-2 addressLineTwo",
                         "placeId": "Ei4xOTUwIEZyYXNlciBTdCAjMjAzLCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEglTMgnU8qOFVBFw8CEtCoGLfhIDMjAz"
                     },
-                    "notes": "Regency Park Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -5756,7 +5950,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/AqcSgl1s1MDonjzYBHM2",
                     "route": {
@@ -5775,7 +5970,7 @@
                         "addressLineTwo": "stop-2-3 addressLineTwo",
                         "placeId": "Ei4yMDMwIEZyYXNlciBTdCAjMTA0LCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEglhbRne8qOFVBFSCCD1RcpNeBIDMTA0"
                     },
-                    "notes": "Regency Park Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -5785,7 +5980,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/AqcSgl1s1MDonjzYBHM2",
                     "route": {
@@ -5804,7 +6000,7 @@
                         "addressLineTwo": "stop-2-4 addressLineTwo",
                         "placeId": "Ei4xOTA1IEZyYXNlciBTdCAjMzAyLCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEgnzNmsnjaOFVBGqtpMnEccmWhIDMzAy"
                     },
-                    "notes": "Regency Park Apartments* - The 1905 building is located on the north side of Fraser, toward the back of the parking lot.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -5814,7 +6010,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/AqcSgl1s1MDonjzYBHM2",
                     "route": {
@@ -5833,7 +6030,7 @@
                         "addressLineTwo": "stop-2-5 addressLineTwo",
                         "placeId": "ChIJ3SGbp4aghVQRSXNpwYagM-4"
                     },
-                    "notes": "House is at the end of the driveway on the right",
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 27,
                     "orderInfo": {
@@ -5843,7 +6040,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/AqcSgl1s1MDonjzYBHM2",
                     "route": {
@@ -5862,7 +6060,7 @@
                         "addressLineTwo": "stop-2-6 addressLineTwo",
                         "placeId": "Ei4xOTcwIEZyYXNlciBTdCAjMzA4LCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEgkpVK7D8qOFVBF3a7irpZ9aIRIDMzA4"
                     },
-                    "notes": "Regency Park Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -5872,7 +6070,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/AqcSgl1s1MDonjzYBHM2",
                     "route": {
@@ -5891,7 +6090,7 @@
                         "addressLineTwo": "stop-2-7 addressLineTwo",
                         "placeId": "Ei4yMDU1IEZyYXNlciBTdCAjMzAxLCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEgnJo8Qt86OFVBFQVaZGz3PkmBIDMzAx"
                     },
-                    "notes": "Regency Park Apartments* - The 2055 building is located on the north side of Fraser.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 21,
                     "orderInfo": {
@@ -5901,7 +6100,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/AqcSgl1s1MDonjzYBHM2",
                     "route": {
@@ -5927,7 +6127,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "Ej1XaGF0Y29tIENvdW50eSwgMjMwNiBEb3VnbGFzIFJkICM0MDMsIEZlcm5kYWxlLCBXQSA5ODI0OCwgVVNBIh8aHQoWChQKEgmv_1ZsO7yFVBGkTaL9jrQ2yRIDNDAz"
                     },
-                    "notes": "Beacon Manor - Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -5937,7 +6137,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/B6gt6pqUNJPO9nhDxfTA",
                     "route": {
@@ -5956,7 +6157,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "Ei0yMzA4IERvdWdsYXMgUmQgIzMwMiwgRmVybmRhbGUsIFdBIDk4MjQ4LCBVU0EiHxodChYKFAoSCf1h9Wo7vIVUETWWAfZamNhIEgMzMDI"
                     },
-                    "notes": "Beacon Manor - Recipient is on the 3rd floor.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -5966,7 +6167,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/B6gt6pqUNJPO9nhDxfTA",
                     "route": {
@@ -5985,7 +6187,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "Ei0yMzA4IERvdWdsYXMgUmQgIzMwNCwgRmVybmRhbGUsIFdBIDk4MjQ4LCBVU0EiHxodChYKFAoSCf1h9Wo7vIVUETWWAfZamNhIEgMzMDQ"
                     },
-                    "notes": "Beacon Manor - Recipient is on the 3rd floor.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -5995,7 +6197,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/B6gt6pqUNJPO9nhDxfTA",
                     "route": {
@@ -6014,7 +6217,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "EjAyMTYwIFdhc2hpbmd0b24gU3QgIzEwOSwgRmVybmRhbGUsIFdBIDk4MjQ4LCBVU0EiHxodChYKFAoSCUcTe_YXvIVUEeIi2Caz38YHEgMxMDk"
                     },
-                    "notes": "Fernview Apartments - Recipient's unit is down a few stairs in the back.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -6024,7 +6227,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/B6gt6pqUNJPO9nhDxfTA",
                     "route": {
@@ -6043,7 +6247,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "EjAyMTYwIFdhc2hpbmd0b24gU3QgIzMwNSwgRmVybmRhbGUsIFdBIDk4MjQ4LCBVU0EiHxodChYKFAoSCUcTe_YXvIVUEeIi2Caz38YHEgMzMDU"
                     },
-                    "notes": "Fernview Apartments - Recipient lives in the second building. If facing the road, their unit is at the top left corner of the building.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -6053,7 +6257,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/B6gt6pqUNJPO9nhDxfTA",
                     "route": {
@@ -6072,7 +6277,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "Ei0yMzEwIERvdWdsYXMgUmQgIzIwNSwgRmVybmRhbGUsIFdBIDk4MjQ4LCBVU0EiHxodChYKFAoSCTPRXG87vIVUEQ4ebAbZ6OOzEgMyMDU"
                     },
-                    "notes": "Beacon Manor",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -6082,7 +6287,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/B6gt6pqUNJPO9nhDxfTA",
                     "route": {
@@ -6101,7 +6307,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -6109,7 +6315,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/B6gt6pqUNJPO9nhDxfTA",
                     "route": {
@@ -6128,7 +6335,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "ChIJb47YwDq8hVQR9QBm65AbcE8"
                     },
-                    "notes": "Lamplighter Mobile Home Park - Take a right at the Lamplighter sign and drive straight back past the dumpster, recipient is in the last trailer on the left. In inclement weather, please leave box under the front porch.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -6138,7 +6345,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/B6gt6pqUNJPO9nhDxfTA",
                     "route": {
@@ -6157,7 +6365,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "EigyMjU0IE1haW4gU3QgYjIsIEZlcm5kYWxlLCBXQSA5ODI0OCwgVVNBIh4aHAoWChQKEgklyNHZIryFVBGVTPwtl4VwAxICYjI"
                     },
-                    "notes": "Ferndale Square Apartments - Complex entrance is the first right after the Main St and Douglas Rd intersection. Inside the complex, stay to the left and find the recipient's unit in the second building. **Please tell Sierra if there is unused food outside the door.**",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -6167,7 +6375,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/B6gt6pqUNJPO9nhDxfTA",
                     "route": {
@@ -6186,7 +6395,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "EjAyMTYwIFdhc2hpbmd0b24gU3QgIzExMCwgRmVybmRhbGUsIFdBIDk4MjQ4LCBVU0EiHxodChYKFAoSCUcTe_YXvIVUEeIi2Caz38YHEgMxMTA"
                     },
-                    "notes": "Fernview Apartments - Recipient's phone is currently deactivated.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -6196,7 +6405,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/B6gt6pqUNJPO9nhDxfTA",
                     "route": {
@@ -6220,7 +6430,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "ChIJb47YwDq8hVQR9QBm65AbcE8"
                     },
-                    "notes": "Lamplighter Mobile Home Park - Recipient's unit in the third mobile home on left after entrance (blue mobile home w/wheelchair ramp). Please place box inside porch gate by front door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 16,
                     "orderInfo": {
@@ -6230,7 +6440,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/B6gt6pqUNJPO9nhDxfTA",
                     "route": {
@@ -6249,7 +6460,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "Ej1XaGF0Y29tIENvdW50eSwgMjMwNiBEb3VnbGFzIFJkICMyMDMsIEZlcm5kYWxlLCBXQSA5ODI0OCwgVVNBIh8aHQoWChQKEgmv_1ZsO7yFVBGkTaL9jrQ2yRIDMjAz"
                     },
-                    "notes": "Beacon Manor - Not a secured building. 200 series apartments are on the ground floor.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -6259,7 +6470,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/B6gt6pqUNJPO9nhDxfTA",
                     "route": {
@@ -6278,7 +6490,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "Ei0yMzEwIERvdWdsYXMgUmQgIzEwMSwgRmVybmRhbGUsIFdBIDk4MjQ4LCBVU0EiHxodChYKFAoSCTPRXG87vIVUEQ4ebAbZ6OOzEgMxMDE"
                     },
-                    "notes": "Beacon Manor",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -6288,7 +6500,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/B6gt6pqUNJPO9nhDxfTA",
                     "route": {
@@ -6307,7 +6520,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "Ej1XaGF0Y29tIENvdW50eSwgMjMwNiBEb3VnbGFzIFJkICMzMDMsIEZlcm5kYWxlLCBXQSA5ODI0OCwgVVNBIh8aHQoWChQKEgmv_1ZsO7yFVBGkTaL9jrQ2yRIDMzAz"
                     },
-                    "notes": "Beacon Manor",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -6317,7 +6530,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/B6gt6pqUNJPO9nhDxfTA",
                     "route": {
@@ -6336,7 +6550,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "Ej1XaGF0Y29tIENvdW50eSwgMjMwNiBEb3VnbGFzIFJkICMyMDEsIEZlcm5kYWxlLCBXQSA5ODI0OCwgVVNBIh8aHQoWChQKEgmv_1ZsO7yFVBGkTaL9jrQ2yRIDMjAx"
                     },
-                    "notes": "Beacon Manor - Recipient is on the 2nd floor.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -6346,7 +6560,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/B6gt6pqUNJPO9nhDxfTA",
                     "route": {
@@ -6365,7 +6580,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "EjAyMTYwIFdhc2hpbmd0b24gU3QgIzIwOCwgRmVybmRhbGUsIFdBIDk4MjQ4LCBVU0EiHxodChYKFAoSCUcTe_YXvIVUEeIi2Caz38YHEgMyMDg"
                     },
-                    "notes": "Fernview Apartments - Recipient's unit is in the back building.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -6375,7 +6590,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/B6gt6pqUNJPO9nhDxfTA",
                     "route": {
@@ -6394,7 +6610,7 @@
                         "addressLineTwo": "stop-1-6 addressLineTwo",
                         "placeId": "EigyMjU0IE1haW4gU3QgYjEsIEZlcm5kYWxlLCBXQSA5ODI0OCwgVVNBIh4aHAoWChQKEgklyNHZIryFVBGVTPwtl4VwAxICYjE"
                     },
-                    "notes": "Ferndale Square Apartments - Complex entrance is the first right after the Main St and Douglas Rd intersection.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -6404,7 +6620,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/B6gt6pqUNJPO9nhDxfTA",
                     "route": {
@@ -6430,7 +6647,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "EisyMzI4IFF1ZWVuIFN0ICM3LCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh0aGwoWChQKEgnd0VueiKOFVBFVnOMKyhfArhIBNw"
                     },
-                    "notes": "Apartment numbers are on the back side of the building, not the side that faces Queen St. To access recipient's unit, turn down the alley behind the building (from Texas St) and park in the large parking lot. You'll see unit numbers from there. Recipient's unit is on the first floor. Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -6440,7 +6657,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/BPh2A4XcInbMkpCKR9ok",
                     "route": {
@@ -6469,7 +6687,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/BPh2A4XcInbMkpCKR9ok",
                     "route": {
@@ -6488,7 +6707,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -6496,7 +6715,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/BPh2A4XcInbMkpCKR9ok",
                     "route": {
@@ -6525,7 +6745,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/BPh2A4XcInbMkpCKR9ok",
                     "route": {
@@ -6544,7 +6765,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "EiwxNTE3IFRleGFzIFN0ICMyMCwgQmVsbGluZ2hhbSwgV0EgOTgyMjksIFVTQSIeGhwKFgoUChIJFx4pKIajhVQRReoNiGEt_1kSAjIw"
                     },
-                    "notes": "Please deliver to the bench by the apartment door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -6554,7 +6775,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/BPh2A4XcInbMkpCKR9ok",
                     "route": {
@@ -6573,7 +6795,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "EioxNjEyIFRleGFzIFN0IGIsIEJlbGxpbmdoYW0sIFdBIDk4MjI5LCBVU0EiOBo2CjESLwoUChIJJxq6hoijhVQRrgi0ch-AMLgQzAwqFAoSCTdhaCGGo4VUEbzEGmvRnzu8EgFi"
                     },
-                    "notes": "Texas Meadows Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -6583,7 +6805,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/BPh2A4XcInbMkpCKR9ok",
                     "route": {
@@ -6602,7 +6825,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "EioxNjA2IFRleGFzIFN0IGEsIEJlbGxpbmdoYW0sIFdBIDk4MjI5LCBVU0EiOBo2CjESLwoUChIJJxq6hoijhVQRrgi0ch-AMLgQxgwqFAoSCTdhaCGGo4VUEbzEGmvRnzu8EgFh"
                     },
-                    "notes": "Texas Meadows - Recipient is in the first apartment in the first single-story duplex.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -6612,7 +6835,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/BPh2A4XcInbMkpCKR9ok",
                     "route": {
@@ -6631,7 +6855,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "ChIJ2VIrm4WjhVQROxCfC-JrdWI"
                     },
-                    "notes": "Handrail leading to front porch is loose, be careful.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -6641,7 +6865,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/BPh2A4XcInbMkpCKR9ok",
                     "route": {
@@ -6660,7 +6885,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "EiwxNDIyIEFsYWJhbWEgU3QgYywgQmVsbGluZ2hhbSwgV0EgOTgyMjksIFVTQSIdGhsKFgoUChIJ9-r9N4ajhVQRry3WDeI3PB4SAWM"
                     },
-                    "notes": "Please deliver to back porch with brown tarp on it and DO NOT KNOCK. If driving East on Alabama, come through the light at Pacific and take your first right at the WTA bus stop. This alleyway will get you to the back of the apartments.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -6670,7 +6895,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/BPh2A4XcInbMkpCKR9ok",
                     "route": {
@@ -6689,7 +6915,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "EioxNjE4IFRleGFzIFN0IGEsIEJlbGxpbmdoYW0sIFdBIDk4MjI5LCBVU0EiOBo2CjESLwoUChIJJxq6hoijhVQRrgi0ch-AMLgQ0gwqFAoSCTdhaCGGo4VUEbzEGmvRnzu8EgFh"
                     },
-                    "notes": "Texas Meadows Apartments - located on a road that loops off of Texas.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -6699,7 +6925,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/BPh2A4XcInbMkpCKR9ok",
                     "route": {
@@ -6723,7 +6950,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "EioyNDI4IFF1ZWVuIFN0IGIsIEJlbGxpbmdoYW0sIFdBIDk4MjI5LCBVU0EiHRobChYKFAoSCTX0ZTGGo4VUETd2V108go7MEgFi"
                     },
-                    "notes": "Access building via the alley and deliver to apartment door. The first doors you see (marked A, B, C and D) are storage units, please go to the right of the building to access apartment doors and deliver to the last door on the left.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -6733,7 +6960,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/BPh2A4XcInbMkpCKR9ok",
                     "route": {
@@ -6752,7 +6980,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "EioxNjEwIFRleGFzIFN0IGEsIEJlbGxpbmdoYW0sIFdBIDk4MjI5LCBVU0EiOBo2CjESLwoUChIJJxq6hoijhVQRrgi0ch-AMLgQygwqFAoSCTdhaCGGo4VUEbzEGmvRnzu8EgFh"
                     },
-                    "notes": "Texas Meadows Apartments - located on a road that loops off of Texas.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -6762,7 +6990,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/BPh2A4XcInbMkpCKR9ok",
                     "route": {
@@ -6791,7 +7020,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/BPh2A4XcInbMkpCKR9ok",
                     "route": {
@@ -6820,7 +7050,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/BPh2A4XcInbMkpCKR9ok",
                     "route": {
@@ -6839,7 +7070,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "EioxNjI2IFRleGFzIFN0IGEsIEJlbGxpbmdoYW0sIFdBIDk4MjI5LCBVU0EiOBo2CjESLwoUChIJJxq6hoijhVQRrgi0ch-AMLgQ2gwqFAoSCTdhaCGGo4VUEbzEGmvRnzu8EgFh"
                     },
-                    "notes": "Texas Meadows Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -6849,7 +7080,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/BPh2A4XcInbMkpCKR9ok",
                     "route": {
@@ -6868,7 +7100,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "ChIJTft-a4ajhVQRnGLs7JYVbRw"
                     },
-                    "notes": "There are two units in this building, please deliver to the lower one. Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -6878,7 +7110,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/BPh2A4XcInbMkpCKR9ok",
                     "route": {
@@ -6904,7 +7137,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "EjAzMzI3IE5vcnRod2VzdCBBdmUgIzcsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHRobChYKFAoSCf9Gwb9ro4VUEUjj_6s9XqMKEgE3"
                     },
-                    "notes": "Google Maps may send you to the wrong place - access this building from Northwest Ave, not Maplewood. Look for the grey building behind little blue house at 3329 Northwest. Unit is up the stairs seen from the parking lot.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -6914,7 +7147,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/CkGPfs4B9D12jfAQRLqx",
                     "route": {
@@ -6933,7 +7167,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "EjQyNzAyIFcgTWFwbGV3b29kIEF2ZSAjMTEwLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEglPSpW8a6OFVBGTkzNbQQTdpxIDMTEw"
                     },
-                    "notes": "Arbor Villa Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -6943,7 +7177,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/CkGPfs4B9D12jfAQRLqx",
                     "route": {
@@ -6962,7 +7197,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "EjQyNzAwIFcgTWFwbGV3b29kIEF2ZSAjMjAzLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgl5anO9a6OFVBG6LfM1aBpL9xIDMjAz"
                     },
-                    "notes": "Arbor Villa Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -6972,7 +7207,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/CkGPfs4B9D12jfAQRLqx",
                     "route": {
@@ -6991,7 +7227,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "EjMyNjQzIFcgTWFwbGV3b29kIEF2ZSAjMzMsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiORo3CjESLwoUChIJMVBgnGujhVQRsDPasESTDWgQ0xQqFAoSCWFBVihHo4VUEQUaEqCaErvzEgIzMw"
                     },
-                    "notes": "Maplewood Place Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -7001,7 +7237,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/CkGPfs4B9D12jfAQRLqx",
                     "route": {
@@ -7020,7 +7257,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "Ei0zMzA3IEhpbGRhIExuICMxMDMsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHxodChYKFAoSCReJpLpro4VUEf7Lvi9aoiCfEgMxMDM"
                     },
-                    "notes": "Hilda Lane Apartments - Recipients are in the last building in the complex (3307), past the garbage cans. Recipient has a gray doormat. PLEASE DO NOT KNOCK, or the dogs will bark.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 16,
                     "orderInfo": {
@@ -7030,7 +7267,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/CkGPfs4B9D12jfAQRLqx",
                     "route": {
@@ -7049,7 +7287,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "EjQyNjE3IFcgTWFwbGV3b29kIEF2ZSAjMTAzLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgn7alN_bKOFVBHZakTmF8cEmRIDMTAz"
                     },
-                    "notes": "Forest Park Apartments - Recipient's unit is behind the mailboxes.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -7059,7 +7297,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/CkGPfs4B9D12jfAQRLqx",
                     "route": {
@@ -7078,7 +7317,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -7086,7 +7325,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/CkGPfs4B9D12jfAQRLqx",
                     "route": {
@@ -7105,7 +7345,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "EjQyNjIxIFcgTWFwbGV3b29kIEF2ZSAjMjEwLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgnrkeKGbKOFVBFZesW9QyyzQhIDMjEw"
                     },
-                    "notes": "Forest Park Apartments - Recipients are Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -7115,7 +7355,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/CkGPfs4B9D12jfAQRLqx",
                     "route": {
@@ -7134,7 +7375,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "Ei0zMzA3IEhpbGRhIExuICMxMDYsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHxodChYKFAoSCReJpLpro4VUEf7Lvi9aoiCfEgMxMDY"
                     },
-                    "notes": "Hilda Lane Apartments - Recipients are in the last building in the complex (3307). Box has been stolen recently. Please knock loud and wait for recipient to answer door, if you are comfortable doing so. Phone is not in service.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -7144,7 +7385,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/CkGPfs4B9D12jfAQRLqx",
                     "route": {
@@ -7163,7 +7405,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "EjAzMzI3IE5vcnRod2VzdCBBdmUgIzYsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHRobChYKFAoSCf9Gwb9ro4VUEUjj_6s9XqMKEgE2"
                     },
-                    "notes": "Google Maps may send you to the wrong place - access this building from Northwest Ave, not Maplewood. Look for the grey building behind little blue house at 3329 Northwest. Unit is up the stairs seen from the parking lot.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -7173,7 +7415,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/CkGPfs4B9D12jfAQRLqx",
                     "route": {
@@ -7197,7 +7440,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "EjIyNjI1IFcgTWFwbGV3b29kIEF2ZSAjNCwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIdGhsKFgoUChIJX6_ef2ujhVQRGk9-LlP7wTwSATQ"
                     },
-                    "notes": "#4 is one of a number of mobile homes behind a blue building addresses as 2625.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -7207,7 +7450,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/CkGPfs4B9D12jfAQRLqx",
                     "route": {
@@ -7226,7 +7470,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "EjAzMzI3IE5vcnRod2VzdCBBdmUgIzUsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHRobChYKFAoSCf9Gwb9ro4VUEUjj_6s9XqMKEgE1"
                     },
-                    "notes": "Google Maps may send you to the wrong place - access this building from Northwest Ave, not Maplewood. Look for the grey building behind little blue house at 3329 Northwest. Unit is up the stairs seen from the parking lot.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -7236,7 +7480,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/CkGPfs4B9D12jfAQRLqx",
                     "route": {
@@ -7255,7 +7500,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "EjQyNjE3IFcgTWFwbGV3b29kIEF2ZSAjMjAzLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgn7alN_bKOFVBHZakTmF8cEmRIDMjAz"
                     },
-                    "notes": "Forest Park Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -7265,7 +7510,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/CkGPfs4B9D12jfAQRLqx",
                     "route": {
@@ -7284,7 +7530,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "EjQyNjE5IFcgTWFwbGV3b29kIEF2ZSAjMjA3LCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgljWTt-bKOFVBEPVybOhvC_mRIDMjA3"
                     },
-                    "notes": "Forest Park Apartments - Recipients building is the second one back from the parking lot entrance.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -7294,7 +7540,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/CkGPfs4B9D12jfAQRLqx",
                     "route": {
@@ -7313,7 +7560,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "EjQyNjA5IFcgTWFwbGV3b29kIEF2ZSAjMTEwLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgk3H_RjbKOFVBGNR-hAiiZlgRIDMTEw"
                     },
-                    "notes": "Forest Park Apartments II",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -7323,7 +7570,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/CkGPfs4B9D12jfAQRLqx",
                     "route": {
@@ -7342,7 +7590,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "EjIyNjMxIFcgTWFwbGV3b29kIEF2ZSAjNiwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIdGhsKFgoUChIJR3dmf2ujhVQRMMJANQa3IW0SATY"
                     },
-                    "notes": "Maplewood Place - Please KNOCK LOUD when making delivery.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -7352,7 +7600,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/CkGPfs4B9D12jfAQRLqx",
                     "route": {
@@ -7371,7 +7620,7 @@
                         "addressLineTwo": "stop-1-6 addressLineTwo",
                         "placeId": "EjQyNzAwIFcgTWFwbGV3b29kIEF2ZSAjMzA1LCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgl5anO9a6OFVBG6LfM1aBpL9xIDMzA1"
                     },
-                    "notes": "Arbor Villa Apartments - Address is not visible from road. Recipient's apartment is on the 3rd floor at the end of the courtyard. Please deliver to the chair by the apartment door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -7381,7 +7630,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/CkGPfs4B9D12jfAQRLqx",
                     "route": {
@@ -7417,7 +7667,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/CmSaO0jX9LzBe5lbuW4V",
                     "route": {
@@ -7436,7 +7687,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "Ei0xMTE2IE4gR2FyZGVuIFN0IGIsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHRobChYKFAoSCT9VNMW4o4VUEapkNUlbnERYEgFi"
                     },
-                    "notes": "Please leave the box under the stairs.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -7446,7 +7697,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/CmSaO0jX9LzBe5lbuW4V",
                     "route": {
@@ -7475,7 +7727,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/CmSaO0jX9LzBe5lbuW4V",
                     "route": {
@@ -7494,7 +7747,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "Eiw3MDEgTiBGb3Jlc3QgU3QgZywgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIdGhsKFgoUChIJEzZhybejhVQRwA_qEofrCuISAWc"
                     },
-                    "notes": "Forest Hill Apartments - Secured building, gate code is 1835. If you are accessing this building from Forest, go down three flights of stairs on the left side of the building to the very bottom. You can also access this address via State Street. Once inside the building, you should see the recipient's door (#G) beyond the laundry room.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -7504,7 +7757,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/CmSaO0jX9LzBe5lbuW4V",
                     "route": {
@@ -7523,7 +7777,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "EjQ4MDAgQmlsbHkgRnJhbmsgSnIuIFN0ICM5LCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh0aGwoWChQKEgmfz6rCx6OFVBG3EnZ2GdYuRRIBOQ"
                     },
-                    "notes": "This building is up against a steep bluff. There is a narrow driveway with no space to turn around at the top, drive up at your own risk. At the top of the driveway, climb the stairs past #6 and turn right under the arch/into a cove area and you'll see #9 on the immediate right. Please USE CAUTION on the stairs, they are slippery when wet.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -7533,7 +7787,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/CmSaO0jX9LzBe5lbuW4V",
                     "route": {
@@ -7552,7 +7807,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "ChIJDde68cejhVQRk1f0Hs5Y48M"
                     },
-                    "notes": "House is on the corner of E Myrtle and an alleyway that connects to Laurel Park.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -7562,7 +7817,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/CmSaO0jX9LzBe5lbuW4V",
                     "route": {
@@ -7581,7 +7837,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "ChIJbR9rl7-jhVQRvjoO_t6ywPY"
                     },
-                    "notes": "Please deliver food box to the porch behind the porch wall by the couch.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -7591,7 +7847,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/CmSaO0jX9LzBe5lbuW4V",
                     "route": {
@@ -7610,7 +7867,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "ChIJT5_0FsCjhVQR2zmafBZB8nI"
                     },
-                    "notes": "House cannot be accessed from Lakeway Dr. Use the unmarked alley off of Humboldt St (parallel to Lakeway, between 1304 and 1310) to find the driveway. You should see a recycling dumpster next to the driveway. There are two recipients at this address, Cameron and Chloe.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -7620,7 +7877,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/CmSaO0jX9LzBe5lbuW4V",
                     "route": {
@@ -7639,7 +7897,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -7647,7 +7905,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/CmSaO0jX9LzBe5lbuW4V",
                     "route": {
@@ -7666,7 +7925,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "ChIJZ5E1V4OjhVQR8-Q7Qzvdmb4"
                     },
-                    "notes": "Please deliver to the door up the driveway on the Humbolt St side of the house.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -7676,7 +7935,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/CmSaO0jX9LzBe5lbuW4V",
                     "route": {
@@ -7700,7 +7960,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "Ei4xNDUwIEh1bWJvbGR0IFN0ICMxLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh0aGwoWChQKEgmBhlRslaOFVBH1WnBaGONG9BIBMQ"
                     },
-                    "notes": "Recipient is Spanish-speaking. Leave box on the front porch.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -7710,7 +7970,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/CmSaO0jX9LzBe5lbuW4V",
                     "route": {
@@ -7729,7 +7990,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "EisxNDAxIEphbWVzIFN0ICM0LCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh0aGwoWChQKEgmHpmU2laOFVBGIS_UkqC6yJRIBNA"
                     },
-                    "notes": "Look for Building A. There are two recipients at this address - Margaryta and Samantha. Please CALL MARGARYTA when delivery is made and do not use the doorbell.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -7739,7 +8000,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/CmSaO0jX9LzBe5lbuW4V",
                     "route": {
@@ -7758,7 +8020,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "ChIJT5_0FsCjhVQR2zmafBZB8nI"
                     },
-                    "notes": "House cannot be accessed from Lakeway Dr. Use the unmarked alley off of Humboldt St (parallel to Lakeway, between 1304 and 1310) to find the driveway. You should see a recycling dumpster next to the driveway. There are two recipients at this address, Cameron and Chloe.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -7768,7 +8030,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/CmSaO0jX9LzBe5lbuW4V",
                     "route": {
@@ -7794,7 +8057,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "EjA5MzcgTWFob2dhbnkgQXZlICMxMDQsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiHxodChYKFAoSCTEXk9JRo4VUEdG1cOi8B-RQEgMxMDQ"
                     },
-                    "notes": "Meadow Wood Townhomes",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -7804,7 +8067,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/D3uSaKL9w15IXCc20oHM",
                     "route": {
@@ -7823,7 +8087,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "EjA5MTkgTWFob2dhbnkgQXZlICMzMDEsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiHxodChYKFAoSCX-vBitOo4VUEZsjfY40Yb6yEgMzMDE"
                     },
-                    "notes": "Meadow Wood Townhomes",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -7833,7 +8097,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/D3uSaKL9w15IXCc20oHM",
                     "route": {
@@ -7852,7 +8117,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "Ei0yNjA4IEFsZGVyd29vZCBBdmUsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiMRIvChQKEglxgiL0aaOFVBHuWyTF-HmMTxCwFCoUChIJBVTtIzyjhVQRWXfiAgnucl8"
                     },
-                    "notes": "Village on the Green Apartments - Please park in a visitor parking spot. Recipient's building is in the back of the complex, to the left of the entrance and their unit is on the second floor.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -7862,7 +8127,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/D3uSaKL9w15IXCc20oHM",
                     "route": {
@@ -7881,7 +8147,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "Ei0yNjM3IEFsZGVyd29vZCBBdmUsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiMRIvChQKEglxgiL0aaOFVBHvWyTF-HmMTxDNFCoUChIJBVTtIzyjhVQRWXfiAgnucl8"
                     },
-                    "notes": "Village on the Green Apartments - Please park in a visitor parking spot. Recipient's unit is on the ground floor.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -7891,7 +8157,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/D3uSaKL9w15IXCc20oHM",
                     "route": {
@@ -7910,7 +8177,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "ChIJG16I52mjhVQRdMpjmadlpB4"
                     },
-                    "notes": "Village on the Green Apartments - Please park in a visitor parking spot. Recipient's unit is upstairs.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -7920,7 +8187,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/D3uSaKL9w15IXCc20oHM",
                     "route": {
@@ -7939,7 +8207,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "EjA5MTkgTWFob2dhbnkgQXZlICMxMDMsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiHxodChYKFAoSCX-vBitOo4VUEZsjfY40Yb6yEgMxMDM"
                     },
-                    "notes": "Meadow Wood Townhomes - Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -7949,7 +8217,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/D3uSaKL9w15IXCc20oHM",
                     "route": {
@@ -7968,7 +8237,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -7976,7 +8245,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/D3uSaKL9w15IXCc20oHM",
                     "route": {
@@ -7995,7 +8265,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "EjEzNTEwIE5vcnRod2VzdCBBdmUgIzEyLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh4aHAoWChQKEgmLP4D-aaOFVBF4FC-Z15ZteBICMTI"
                     },
-                    "notes": "Recipient lives in the light green house right off of Northwest in front of the large apartment building.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -8005,7 +8275,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/D3uSaKL9w15IXCc20oHM",
                     "route": {
@@ -8024,7 +8295,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "ChIJiQ4d6WmjhVQRuCKeH9FWDRk"
                     },
-                    "notes": "Village on the Green Apartments - Please park in a visitor parking spot.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -8034,7 +8305,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/D3uSaKL9w15IXCc20oHM",
                     "route": {
@@ -8053,7 +8325,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "EjA5MTkgTWFob2dhbnkgQXZlICMyMDMsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiHxodChYKFAoSCX-vBitOo4VUEZsjfY40Yb6yEgMyMDM"
                     },
-                    "notes": "Meadow Wood Townhomes - Food has been stolen from porch. PLEASE CALL BEFORE LEAVING HER BOX AT HER DOOR.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -8063,7 +8335,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/D3uSaKL9w15IXCc20oHM",
                     "route": {
@@ -8087,7 +8360,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "EjA5MTUgTWFob2dhbnkgQXZlICMyMDIsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiHxodChYKFAoSCW2KBvA2o4VUEWwJKZ5nV2Z-EgMyMDI"
                     },
-                    "notes": "Meadow Wood Townhomes - Building 915. Deliveries have been stolen in the past, please try calling Erica before delivering her box to be sure she receives it.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -8097,7 +8370,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/D3uSaKL9w15IXCc20oHM",
                     "route": {
@@ -8116,7 +8390,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "EjA5MjMgTWFob2dhbnkgQXZlICMxMDMsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiHxodChYKFAoSCQnQJNRRo4VUETOVgAV1KBiUEgMxMDM"
                     },
-                    "notes": "Meadow Wood Townhomes - Ring door bell",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -8126,7 +8400,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/D3uSaKL9w15IXCc20oHM",
                     "route": {
@@ -8145,7 +8420,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "EjA5MTkgTWFob2dhbnkgQXZlICMxMDQsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiHxodChYKFAoSCX-vBitOo4VUEZsjfY40Yb6yEgMxMDQ"
                     },
-                    "notes": "Meadow Wood Townhomes - Please ring doorbell.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -8155,7 +8430,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/D3uSaKL9w15IXCc20oHM",
                     "route": {
@@ -8174,7 +8450,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "EjA5MjcgTWFob2dhbnkgQXZlICMyMDMsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiHxodChYKFAoSCanQvylQo4VUEc-s10GggIcMEgMyMDM"
                     },
-                    "notes": "Meadow Wood Townhomes - Recipient's unit is on the second floor.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -8184,7 +8460,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/D3uSaKL9w15IXCc20oHM",
                     "route": {
@@ -8203,7 +8480,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "EjEzNTEwIE5vcnRod2VzdCBBdmUgIzExLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh4aHAoWChQKEgmLP4D-aaOFVBF4FC-Z15ZteBICMTE"
                     },
-                    "notes": "Address numbers may not be visible from the street, covered by shrubs. Recipient's unit is up the stairs and directly to the right.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -8213,7 +8490,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/D3uSaKL9w15IXCc20oHM",
                     "route": {
@@ -8232,7 +8510,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "EjA5MTkgTWFob2dhbnkgQXZlICMyMDQsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiHxodChYKFAoSCX-vBitOo4VUEZsjfY40Yb6yEgMyMDQ"
                     },
-                    "notes": "Meadow Wood Townhomes - Please deliver to front porch and ring doorbell.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -8242,7 +8520,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/D3uSaKL9w15IXCc20oHM",
                     "route": {
@@ -8278,7 +8557,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/Elwb5KIcI6ZeTWO5D2Ek",
                     "route": {
@@ -8297,7 +8577,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "EjEzMzEzIENoZXJyeXdvb2QgQXZlIHo0LCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh4aHAoWChQKEgnZpJnwO6OFVBHikrZM31OWABICejQ"
                     },
-                    "notes": "Village Apartments - Alternate phone number is 360-366-8346",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -8307,7 +8587,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/Elwb5KIcI6ZeTWO5D2Ek",
                     "route": {
@@ -8326,7 +8607,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "ChIJZ2glkhmjhVQRSFzh_QjY19o"
                     },
-                    "notes": "House is across Bennett from the Fire Station. There is a ramp up to the front door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -8336,7 +8617,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/Elwb5KIcI6ZeTWO5D2Ek",
                     "route": {
@@ -8355,7 +8637,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "EjAzMzMzIEhvbGx5d29vZCBBdmUgIzksIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHRobChYKFAoSCQ0vP007o4VUETTtI9OusAUiEgE5"
                     },
-                    "notes": "Please deliver to FRONT (street-facing) apartment door and knock.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -8365,7 +8647,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/Elwb5KIcI6ZeTWO5D2Ek",
                     "route": {
@@ -8384,7 +8667,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "EjAzMzMzIEhvbGx5d29vZCBBdmUgIzUsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHRobChYKFAoSCQ0vP007o4VUETTtI9OusAUiEgE1"
                     },
-                    "notes": "There are two recipients at this address (Glenna and Susan), please deliver both boxes to the door and knock.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -8394,7 +8677,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/Elwb5KIcI6ZeTWO5D2Ek",
                     "route": {
@@ -8413,7 +8697,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "EjEzMzI4IE1jQWxwaW5lIFJkICMxMDZhLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIiAaHgoWChQKEgnnEEEvPaOFVBGG_dFQwbeZTRIEMTA2YQ"
                     },
-                    "notes": "The Birches",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -8423,7 +8707,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/Elwb5KIcI6ZeTWO5D2Ek",
                     "route": {
@@ -8442,7 +8727,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "EjEzMzI4IE1jQWxwaW5lIFJkICMxMDdiLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIiAaHgoWChQKEgnnEEEvPaOFVBGG_dFQwbeZTRIEMTA3Yg"
                     },
-                    "notes": "The Birches",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -8452,7 +8737,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/Elwb5KIcI6ZeTWO5D2Ek",
                     "route": {
@@ -8471,7 +8757,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "EjEzMzI4IE1jQWxwaW5lIFJkICMxMTZiLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIiAaHgoWChQKEgnnEEEvPaOFVBGG_dFQwbeZTRIEMTE2Yg"
                     },
-                    "notes": "The Birches",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -8481,7 +8767,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/Elwb5KIcI6ZeTWO5D2Ek",
                     "route": {
@@ -8500,7 +8787,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "EjEzMzI4IE1jQWxwaW5lIFJkICMxMTRiLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIiAaHgoWChQKEgnnEEEvPaOFVBGG_dFQwbeZTRIEMTE0Yg"
                     },
-                    "notes": "The Birches",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -8510,7 +8797,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/Elwb5KIcI6ZeTWO5D2Ek",
                     "route": {
@@ -8529,7 +8817,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -8537,7 +8825,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/Elwb5KIcI6ZeTWO5D2Ek",
                     "route": {
@@ -8561,7 +8850,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "EjAzMzMzIEhvbGx5d29vZCBBdmUgIzUsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHRobChYKFAoSCQ0vP007o4VUETTtI9OusAUiEgE1"
                     },
-                    "notes": "There are two recipients at this address (Glenna and Susan), please deliver both boxes to the door and knock.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -8571,7 +8860,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/Elwb5KIcI6ZeTWO5D2Ek",
                     "route": {
@@ -8600,7 +8890,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/Elwb5KIcI6ZeTWO5D2Ek",
                     "route": {
@@ -8619,7 +8910,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "EjAzMzQwIENoZXJyeXdvb2QgQXZlIGYsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHRobChYKFAoSCd3JI-Y7o4VUEapqaXRnXOUhEgFm"
                     },
-                    "notes": "Recipient is in an unnamed complex on Cherrywood (NOT at Village Apartments, but across the street). Look for the 'SLOW children at play' sign on the pole by the mailboxes, and turn in. Recipient is in the last duplex on the right, unit F.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -8629,7 +8920,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/Elwb5KIcI6ZeTWO5D2Ek",
                     "route": {
@@ -8658,7 +8950,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/Elwb5KIcI6ZeTWO5D2Ek",
                     "route": {
@@ -8687,7 +8980,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/Elwb5KIcI6ZeTWO5D2Ek",
                     "route": {
@@ -8716,7 +9010,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/Elwb5KIcI6ZeTWO5D2Ek",
                     "route": {
@@ -8742,7 +9037,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "ChIJC7sURcKjhVQR2cX6FETlFb8"
                     },
-                    "notes": "Lakeway Mobile Estates - Deliver to the porch accessed from the carport and KNOCK LOUDLY.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 20,
                     "orderInfo": {
@@ -8752,7 +9047,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/HOl4udBbj26B1r9TzAG0",
                     "route": {
@@ -8771,7 +9067,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "Ei8xNTA1IE4gU3RhdGUgU3QgIzEwMSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJq4jo8b2jhVQRbLdK5UuiuZYSAzEwMQ"
                     },
-                    "notes": "Walton Place* - Please note this recipient is in Walton Place 2 building, 1505 N State, not 1511 N State.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -8781,7 +9077,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/HOl4udBbj26B1r9TzAG0",
                     "route": {
@@ -8800,7 +9097,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "ChIJC7sURcKjhVQRvWq-Vt0dahY"
                     },
-                    "notes": "Lakeway Mobile Estates - Yellow/tan trailer on the corner of Rutgers and 9th. Follow the ramp to the front of the unit.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 16,
                     "orderInfo": {
@@ -8810,7 +9107,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/HOl4udBbj26B1r9TzAG0",
                     "route": {
@@ -8829,7 +9127,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "ChIJC7sURcKjhVQR2Al_TNnVAW8"
                     },
-                    "notes": "Lakeway Mobile Estates - Unit is on 3rd St.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 19,
                     "orderInfo": {
@@ -8839,7 +9137,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/HOl4udBbj26B1r9TzAG0",
                     "route": {
@@ -8858,7 +9157,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "Ei8xNTExIE4gU3RhdGUgU3QgIzM1NSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJf5vr9b2jhVQRn3rfQFH61QsSAzM1NQ"
                     },
-                    "notes": "Walton Place* - try calling this recipient first.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -8868,7 +9167,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/HOl4udBbj26B1r9TzAG0",
                     "route": {
@@ -8887,7 +9187,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "Ei8xNTExIE4gU3RhdGUgU3QgIzQ1MiwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJf5vr9b2jhVQRn3rfQFH61QsSAzQ1Mg"
                     },
-                    "notes": "Walton Place*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -8897,7 +9197,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/HOl4udBbj26B1r9TzAG0",
                     "route": {
@@ -8916,7 +9217,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "ChIJC7sURcKjhVQR-XQxaKui9YE"
                     },
-                    "notes": "Lakeway Mobile Estates",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 17,
                     "orderInfo": {
@@ -8926,7 +9227,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/HOl4udBbj26B1r9TzAG0",
                     "route": {
@@ -8945,7 +9247,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "EisxNDAwIE1vb3JlIFN0IGE0LCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh4aHAoWChQKEgnnVm8366OFVBH1mJdWJmSMThICYTQ"
                     },
-                    "notes": "Park Terrace Apartments - Secured building. **Easiest to deliver to this apartment first.** From Moore St, enter door with numbers A1-A8 above it. After entering, go up a half flight of stairs and then down to reach recipient's apartment.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -8955,7 +9257,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/HOl4udBbj26B1r9TzAG0",
                     "route": {
@@ -8974,7 +9277,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "ChIJC7sURcKjhVQR-GqbgC4XutM"
                     },
-                    "notes": "Lakeway Mobile Estates - Unit is on 3rd St.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -8984,7 +9287,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/HOl4udBbj26B1r9TzAG0",
                     "route": {
@@ -9003,7 +9307,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "Ei8xNTExIE4gU3RhdGUgU3QgIzE1NSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJf5vr9b2jhVQRn3rfQFH61QsSAzE1NQ"
                     },
-                    "notes": "Walton Place* - Deliver to recipient's door that is accesible from the outside of the building.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -9013,7 +9317,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/HOl4udBbj26B1r9TzAG0",
                     "route": {
@@ -9037,7 +9342,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "ChIJC7sURcKjhVQRAysgBnzphB8"
                     },
-                    "notes": "Lakeway Mobile Estates - Recipient is located at the corner of 5th and Lincoln Blvd, immediately to the right as you enter from Lincoln St (if using the entrance across from Pizza Hut).",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 18,
                     "orderInfo": {
@@ -9047,7 +9352,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/HOl4udBbj26B1r9TzAG0",
                     "route": {
@@ -9066,7 +9372,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -9074,7 +9380,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/HOl4udBbj26B1r9TzAG0",
                     "route": {
@@ -9093,7 +9400,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "EiwxMDYwIFlvcmsgU3QgIzExMywgQmVsbGluZ2hhbSwgV0EgOTgyMjksIFVTQSIfGh0KFgoUChIJQ7R2b5OjhVQRjQ4Fdj3vaFgSAzExMw"
                     },
-                    "notes": "York Garden Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -9103,7 +9410,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/HOl4udBbj26B1r9TzAG0",
                     "route": {
@@ -9122,7 +9430,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "Ei8xNTA1IE4gU3RhdGUgU3QgIzQwOSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJq4jo8b2jhVQRbLdK5UuiuZYSAzQwOQ"
                     },
-                    "notes": "Walton Place* - Please note this recipient is in Walton Place 2 building, 1505 N State, not 1511 N State.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -9132,7 +9440,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/HOl4udBbj26B1r9TzAG0",
                     "route": {
@@ -9151,7 +9460,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "Ei8xNTExIE4gU3RhdGUgU3QgIzQ1NSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJf5vr9b2jhVQRn3rfQFH61QsSAzQ1NQ"
                     },
-                    "notes": "Walton Place* - Please RING DOORBELL when you deliver her box.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -9161,7 +9470,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/HOl4udBbj26B1r9TzAG0",
                     "route": {
@@ -9180,7 +9490,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "Ei4xMDQwIEZyYXNlciBTdCAjMjAzLCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEgmJ41Wik6OFVBHgvjQB-0NiuRIDMjAz"
                     },
-                    "notes": "Willow Creek Apartments - Side facing street, second floor. Please knock two or three times.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -9190,7 +9500,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/HOl4udBbj26B1r9TzAG0",
                     "route": {
@@ -9209,7 +9520,7 @@
                         "addressLineTwo": "stop-1-6 addressLineTwo",
                         "placeId": "ChIJC7sURcKjhVQRKkre48ry4IQ"
                     },
-                    "notes": "Lakeway Mobile Estates - Unit is on the corner of 8th and Shasta Blvd, toward the back of the park.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -9219,7 +9530,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/HOl4udBbj26B1r9TzAG0",
                     "route": {
@@ -9238,7 +9550,7 @@
                         "addressLineTwo": "stop-1-7 addressLineTwo",
                         "placeId": "Ei4xMDQwIEZyYXNlciBTdCAjMjA4LCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEgmJ41Wik6OFVBHgvjQB-0NiuRIDMjA4"
                     },
-                    "notes": "Willow Creek Apartments - Recipient's unit is upstairs.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -9248,7 +9560,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/HOl4udBbj26B1r9TzAG0",
                     "route": {
@@ -9267,7 +9580,7 @@
                         "addressLineTwo": "stop-1-8 addressLineTwo",
                         "placeId": "EiwxMDYwIFlvcmsgU3QgIzEwMywgQmVsbGluZ2hhbSwgV0EgOTgyMjksIFVTQSIfGh0KFgoUChIJQ7R2b5OjhVQRjQ4Fdj3vaFgSAzEwMw"
                     },
-                    "notes": "York Garden Apartments - Not a secured building, please leave at door",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -9277,7 +9590,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/HOl4udBbj26B1r9TzAG0",
                     "route": {
@@ -9296,7 +9610,7 @@
                         "addressLineTwo": "stop-1-9 addressLineTwo",
                         "placeId": "EisxNDAwIE1vb3JlIFN0IGMyLCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh4aHAoWChQKEgnnVm8366OFVBH1mJdWJmSMThICYzI"
                     },
-                    "notes": "Park Terrace Apartments - Secured building. Entrance is in the courtyard. Go to the second set of glass doors marked C1-C8 (not C2). These doors are locked so call/text upon arrival and recipient will unlock the door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -9306,7 +9620,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/HOl4udBbj26B1r9TzAG0",
                     "route": {
@@ -9330,7 +9645,7 @@
                         "addressLineTwo": "stop-2-0 addressLineTwo",
                         "placeId": "ChIJvWZXSCijhVQRbMplLsCpg2c"
                     },
-                    "notes": "York Garden Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -9340,7 +9655,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/HOl4udBbj26B1r9TzAG0",
                     "route": {
@@ -9366,7 +9682,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "EjIyMzQgRSBCYWtlcnZpZXcgUmQgIzIwNywgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJRy0GuaCkhVQRTsBnMrDMXRwSAzIwNw"
                     },
-                    "notes": "Bakerview Terrace - Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -9376,7 +9692,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/ICRjW9mmIRqmCjYsWBP7",
                     "route": {
@@ -9395,7 +9712,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "Ei4xMzUgUHJpbmNlIEF2ZSAjMTA1LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgnLeTOvoKSFVBEL7z946HJiSRIDMTA1"
                     },
-                    "notes": "Benjamin Court - Recipient's building is to the right, their unit is on the main floor.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -9405,7 +9722,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/ICRjW9mmIRqmCjYsWBP7",
                     "route": {
@@ -9424,7 +9742,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "ChIJLRp3RFujhVQR2lFjC4hyMuI"
                     },
-                    "notes": "Bakerview Estates - Mobile home park behind Bellis Fair. Turn right when you enter the complex and then left onto the street after the mailboxes to find  B  addresses. Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -9434,7 +9752,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/ICRjW9mmIRqmCjYsWBP7",
                     "route": {
@@ -9453,7 +9772,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -9461,7 +9780,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/ICRjW9mmIRqmCjYsWBP7",
                     "route": {
@@ -9480,7 +9800,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "ChIJ1U3ZbVujhVQR3cV-HhyOjIw"
                     },
-                    "notes": "Recipient lives in the townhomes near the mobile home park (Bakerview Estates). Please call when making the delivery.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -9490,7 +9810,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/ICRjW9mmIRqmCjYsWBP7",
                     "route": {
@@ -9509,7 +9830,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "ChIJLRp3RFujhVQR2lFjC4hyMuI"
                     },
-                    "notes": "Bakerview Estates - Mobile home park behind Bellis Fair.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -9519,7 +9840,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/ICRjW9mmIRqmCjYsWBP7",
                     "route": {
@@ -9538,7 +9860,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "ChIJLRp3RFujhVQR2lFjC4hyMuI"
                     },
-                    "notes": "Bakerview Estates - Mobile home park behind Bellis Fair. Their trailer is #2B as in boy, NOT #28. Turn right when you enter the complex and then left onto the street after the mailboxes to find  B  addresses, you'll see license plates on the wall.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -9548,7 +9870,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/ICRjW9mmIRqmCjYsWBP7",
                     "route": {
@@ -9567,7 +9890,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "ChIJLRp3RFujhVQR2lFjC4hyMuI"
                     },
-                    "notes": "Bakerview Estates - Mobile home park behind Bellis Fair. Recipient's space is in the first inner loop, closest to the park entrance.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -9577,7 +9900,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/ICRjW9mmIRqmCjYsWBP7",
                     "route": {
@@ -9596,7 +9920,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "ChIJLRp3RFujhVQR2lFjC4hyMuI"
                     },
-                    "notes": "Bakerview Estates - Mobile home park behind Bellis Fair. Recipient's space is in the first inner loop, closest to the park entrance. Every other week, there are two recipients at this address (Faerie and Osheanna). Please deliver both boxes to trailer door. If you don't have Faerie's name on your manifest, they will not get a box that week.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -9606,7 +9930,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/ICRjW9mmIRqmCjYsWBP7",
                     "route": {
@@ -9625,7 +9950,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "ChIJLRp3RFujhVQR2lFjC4hyMuI"
                     },
-                    "notes": "Bakerview Estates - Mobile home park behind Bellis Fair. Turn right when you enter the complex and then left onto the street after the mailboxes to find  B  addresses. Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -9635,7 +9960,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/ICRjW9mmIRqmCjYsWBP7",
                     "route": {
@@ -9659,7 +9985,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "Ei4yNTYgUHJpbmNlIEF2ZSAjMTEwLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgl7wsploaSFVBGiImqXq68nCRIDMTEw"
                     },
-                    "notes": "Sophia Place - Secured building that requires a fob for entry. Recipient has requested boxes be left outside the building's front doors.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -9669,7 +9995,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/ICRjW9mmIRqmCjYsWBP7",
                     "route": {
@@ -9688,7 +10015,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "ChIJLRp3RFujhVQR2lFjC4hyMuI"
                     },
-                    "notes": "Bakerview Estates - Mobile home park behind Bellis Fair. Trailer is at the front of the park on the right.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -9698,7 +10025,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/ICRjW9mmIRqmCjYsWBP7",
                     "route": {
@@ -9717,7 +10045,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "EjIyMjggRSBCYWtlcnZpZXcgUmQgIzIwMywgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJndt0vaCkhVQRXnOJHcjxFNwSAzIwMw"
                     },
-                    "notes": "Bakerview Terrace - Building is white and green and recipient's unit is on the second floor, across from garbage cans.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -9727,7 +10055,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/ICRjW9mmIRqmCjYsWBP7",
                     "route": {
@@ -9746,7 +10075,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "EjI0MTggVyBCYWtlcnZpZXcgUmQgIzUwNiwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJ1f-UxVujhVQR3YVlB9N5OVMSAzUwNg"
                     },
-                    "notes": "The Vantage Apartments - Gate code 1218",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -9756,7 +10085,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/ICRjW9mmIRqmCjYsWBP7",
                     "route": {
@@ -9775,7 +10105,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "EjIyNTIgRSBCYWtlcnZpZXcgUmQgIzEyMiwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJk6P6v6CkhVQRUDrxiz7DN2wSAzEyMg"
                     },
-                    "notes": "Bakerview Terrace Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -9785,7 +10115,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/ICRjW9mmIRqmCjYsWBP7",
                     "route": {
@@ -9804,7 +10135,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "ChIJLRp3RFujhVQR2lFjC4hyMuI"
                     },
-                    "notes": "Bakerview Estates - Mobile home park behind Bellis Fair.  A  addresses are in the first inner loop, closest to the park entrance.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -9814,7 +10145,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/ICRjW9mmIRqmCjYsWBP7",
                     "route": {
@@ -9840,7 +10172,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "ChIJY3tMxVyjhVQR_6N6KU80rWk"
                     },
-                    "notes": "Deliver to porch.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -9850,7 +10182,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/IRMeseiNhiet2kSc6JiK",
                     "route": {
@@ -9869,7 +10202,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "Ei81MjggU3RlcmxpbmcgRHIgIzEwOCwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJV6nqJkOjhVQRIEEbGprhGIoSAzEwOA"
                     },
-                    "notes": "Sterling Senior Apartments* - Recipient has cognitive challenges. May need to reassure her that the deliveries are free of charge, if you interact with her.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -9879,7 +10212,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/IRMeseiNhiet2kSc6JiK",
                     "route": {
@@ -9898,7 +10232,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "Ei81MjggU3RlcmxpbmcgRHIgIzMwNCwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJV6nqJkOjhVQRIEEbGprhGIoSAzMwNA"
                     },
-                    "notes": "Sterling Senior Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -9908,7 +10242,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/IRMeseiNhiet2kSc6JiK",
                     "route": {
@@ -9927,7 +10262,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "Ei81MjggU3RlcmxpbmcgRHIgIzMwNywgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJV6nqJkOjhVQRIEEbGprhGIoSAzMwNw"
                     },
-                    "notes": "Sterling Senior Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -9937,7 +10272,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/IRMeseiNhiet2kSc6JiK",
                     "route": {
@@ -9956,7 +10292,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "Ei81MjggU3RlcmxpbmcgRHIgIzMwMywgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJV6nqJkOjhVQRIEEbGprhGIoSAzMwMw"
                     },
-                    "notes": "Sterling Senior Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -9966,7 +10302,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/IRMeseiNhiet2kSc6JiK",
                     "route": {
@@ -9985,7 +10322,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "Ei81MjggU3RlcmxpbmcgRHIgIzEwMSwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJV6nqJkOjhVQRIEEbGprhGIoSAzEwMQ"
                     },
-                    "notes": "Sterling Senior Apartments* - Please place box on green bench beside apartment door. This recipient is best to call first to get into the building. Alternate phone number is 360-319-7834.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -9995,7 +10332,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/IRMeseiNhiet2kSc6JiK",
                     "route": {
@@ -10014,7 +10352,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "Ei81MTYgU3RlcmxpbmcgRHIgIzEwMiwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJga5qNEOjhVQRBVKkSZW3ryESAzEwMg"
                     },
-                    "notes": "Sterling Meadows - Apartment is located at the back of the property behind the playground. Ring door bell.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -10024,7 +10362,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/IRMeseiNhiet2kSc6JiK",
                     "route": {
@@ -10043,7 +10382,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "Ei81MDIgU3RlcmxpbmcgRHIgIzEwNCwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJny5nK0OjhVQRKCzTskMWinASAzEwNA"
                     },
-                    "notes": "Sterling Meadows - Recipient is Punjabi-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -10053,7 +10392,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/IRMeseiNhiet2kSc6JiK",
                     "route": {
@@ -10072,7 +10412,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -10080,7 +10420,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/IRMeseiNhiet2kSc6JiK",
                     "route": {
@@ -10099,7 +10440,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "Ei81MjggU3RlcmxpbmcgRHIgIzExMCwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJV6nqJkOjhVQRIEEbGprhGIoSAzExMA"
                     },
-                    "notes": "Sterling Senior Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -10109,7 +10450,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/IRMeseiNhiet2kSc6JiK",
                     "route": {
@@ -10133,7 +10475,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "Ei81MjAgU3RlcmxpbmcgRHIgIzEwNSwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJDaS1MUOjhVQR5X6RM-dgXI4SAzEwNQ"
                     },
-                    "notes": "Sterling Meadows",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -10143,7 +10485,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/IRMeseiNhiet2kSc6JiK",
                     "route": {
@@ -10169,7 +10512,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "Ei4zOTU0IEJ5cm9uIEF2ZSAjMzA1LCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIjoaOAoxEi8KFAoSCTnL0eLao4VUEdw5fdqPwEsGEPIeKhQKEgkZccR63KOFVBFusH3PVbSqkRIDMzA1"
                     },
-                    "notes": "Samish Ridge Apartments -  Recipient is in the second building on the right (#4).",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -10179,7 +10522,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/JtojZVSkRBEvhaMAveBR",
                     "route": {
@@ -10198,7 +10542,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "Ei4zMTQwIEFkYW1zIEF2ZSBjMTAxLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIiAaHgoWChQKEgll8Se906OFVBGh4B7WnlWF2RIEYzEwMQ"
                     },
-                    "notes": "Newport Apartments - Take the driveway directly after the mailboxes. Recipient is in the corner unit on the ground floor, closest to the sidewalk, street, and mailboxes.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -10208,7 +10552,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/JtojZVSkRBEvhaMAveBR",
                     "route": {
@@ -10227,7 +10572,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "Ei8xNzA1IEUgTWFwbGUgU3QgIzIxMSwgQmVsbGluZ2hhbSwgV0EgOTgyMjksIFVTQSIfGh0KFgoUChIJ59msUMOjhVQRoPrYPKbZzq8SAzIxMQ"
                     },
-                    "notes": "Maple Park Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -10237,7 +10582,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/JtojZVSkRBEvhaMAveBR",
                     "route": {
@@ -10256,7 +10602,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "Ei4yMjQgQXNobGV5IEF2ZSAjMTAxLCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEgnvQZmu26OFVBHsipwVpzAY2BIDMTAx"
                     },
-                    "notes": "Recipients live on a steep hill.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -10266,7 +10612,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/JtojZVSkRBEvhaMAveBR",
                     "route": {
@@ -10285,7 +10632,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -10293,7 +10640,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/JtojZVSkRBEvhaMAveBR",
                     "route": {
@@ -10312,7 +10660,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "EjYzMDAwIEJpbGwgTWNEb25hbGQgUGt3eSAjMjQsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHhocChYKFAoSCYNbMUDSo4VUEYCXlgNLSem2EgIyNA"
                     },
-                    "notes": "Timberline Apartments - Building number can be hard to see, look for corrugated metal siding. Recipient is on the second floor on the right. *Complex sign appears to be missing as of 11/3/23.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -10322,7 +10670,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/JtojZVSkRBEvhaMAveBR",
                     "route": {
@@ -10341,7 +10690,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "Ei4xMjUyIE5ldmFkYSBTdCAjMzAyLCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEgknWtTN66OFVBEYzp3Akoxm8BIDMzAy"
                     },
-                    "notes": "*Cannot get to apartment from Nevada St* Building is tucked away behind 7-Eleven. Turn on Pacific St just past the Papa Murphy's, and then a right at the Foothills Apartments. Complex is at the end of this road.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -10351,7 +10700,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/JtojZVSkRBEvhaMAveBR",
                     "route": {
@@ -10370,7 +10720,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "Ei4xMTAgQXNobGV5IEF2ZSAjMTA1LCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEgm3kxhr26OFVBF7n06qVHojgxIDMTA1"
                     },
-                    "notes": "East Ridge Apartment Homes - Walk through the gate to get to recipient's door. Knock and caregiver will bring in.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -10380,7 +10730,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/JtojZVSkRBEvhaMAveBR",
                     "route": {
@@ -10399,7 +10750,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "Ei8xNzE1IEUgTWFwbGUgU3QgIzEyNywgQmVsbGluZ2hhbSwgV0EgOTgyMjksIFVTQSIfGh0KFgoUChIJ6R1tXMOjhVQRuwb6ejfXt8QSAzEyNw"
                     },
-                    "notes": "Maple Park Apartments - Please deliver box to black and white checkered mat outside door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -10409,7 +10760,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/JtojZVSkRBEvhaMAveBR",
                     "route": {
@@ -10428,7 +10780,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "Eio1MjkgMzJuZCBTdCAjNTksIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHhocChYKFAoSCdVOYt8Po4VUEY8SRxF9EKdNEgI1OQ"
                     },
-                    "notes": "Bell Mall Villa 2 Apartments - Deliver to apartment door. Don't be thrown off by the lockbox on the door, that is there for emergency purposes.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -10438,7 +10790,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/JtojZVSkRBEvhaMAveBR",
                     "route": {
@@ -10462,7 +10815,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "Ei4zMDEwIEZlcnJ5IEF2ZSAjMzE1LCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgm_NtVN0qOFVBF9eC3y9eGMQxIDMzE1"
                     },
-                    "notes": "Recipient's unit is in building D - the last building on the right after entering the complex.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -10472,7 +10825,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/JtojZVSkRBEvhaMAveBR",
                     "route": {
@@ -10491,7 +10845,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "Eio2MjEgMzJuZCBTdCAjMzQsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHhocChYKFAoSCZ34Pu7To4VUETkEhguNfIUuEgIzNA"
                     },
-                    "notes": "Arise Apartments - Blue building. Recipient's unit is in the middle of the south building, on the second floor.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -10501,7 +10855,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/JtojZVSkRBEvhaMAveBR",
                     "route": {
@@ -10520,7 +10875,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "Ei44NjUgVmlraW5nIENpciAjMTA0LCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEgm3dH7Tw6OFVBHuuZXl8jCDSRIDMTA0"
                     },
-                    "notes": "Lark Bellingham - Secure building, but gate is usually open during delivery window. If it is not, please call recipient to be let in. Can use their parking spot (marked #205) when delivering.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -10530,7 +10885,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/JtojZVSkRBEvhaMAveBR",
                     "route": {
@@ -10549,7 +10905,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "EjgyOTAxIEJpbGwgTWNEb25hbGQgUGt3eSA1MzMgYSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIhGh8KFgoUChIJcey7GtKjhVQRYT1TKXIIXukSBTUzMyBh"
                     },
-                    "notes": "Birnam Wood Apartments - After turning off of Bill McDonald Pkwy into the complex, drive past the top of the hill and look for the third grouping of apartments, the 500 level buildings. From the parking lot, take the second set of stairs, then up another small set of stairs and their unit is on the left.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -10559,7 +10915,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/JtojZVSkRBEvhaMAveBR",
                     "route": {
@@ -10578,7 +10935,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "ChIJrzIjg9OjhVQRSUTs-RMcnqQ"
                     },
-                    "notes": "Cypress Place - There are two home delivery recipients at this address. Park in front of the gazebo. Call recipient when you pull in, the buzzer only works sometimes. Please deliver both boxes to the 2nd patio on your right, the one with all the plants.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -10588,7 +10945,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/JtojZVSkRBEvhaMAveBR",
                     "route": {
@@ -10607,7 +10965,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "ChIJrzIjg9OjhVQRSUTs-RMcnqQ"
                     },
-                    "notes": "Cypress Place - There are two home delivery recipients at this address. Park in front of the gazebo. Call recipient when you pull in, the buzzer only works sometimes. Please deliver both boxes to the 2nd patio on your right, the one with all the plants.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -10617,7 +10975,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/JtojZVSkRBEvhaMAveBR",
                     "route": {
@@ -10643,7 +11002,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "ChIJv_2etce3hVQRXE1mLMcSa1Q"
                     },
-                    "notes": "The mailbox at the end of the driveway says 299. There are several trailers as you come in the driveway. Look for the white one on the farthest left, behind the barn. There will be a grey 1987 Ford F150 in front of it. May or may not be puppies loose in the driveway, use caution. You may also hear a dog barking inside the trailer, but you are safe.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -10653,7 +11012,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -10672,7 +11032,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -10680,7 +11040,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -10699,7 +11060,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "EjE5MjAgQmlyY2ggQmF5IEx5bmRlbiBSZCAjNiwgTHluZGVuLCBXQSA5ODI2NCwgVVNBIh0aGwoWChQKEglTxAYTJriFVBHFFFxkMwzd9hIBNg"
                     },
-                    "notes": "Maberry farm worker housing - Follow the long driveway (Rathbone Rd) off of Birch Bay Lynden Rd to get to apartments. Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -10709,7 +11070,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -10728,7 +11090,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "EiEzNTMgRSBTdCBiLCBCbGFpbmUsIFdBIDk4MjMwLCBVU0EiHRobChYKFAoSCaORU2YAxIVUEdZF1J3nhwJGEgFi"
                     },
-                    "notes": "Recipient's unit is all the way in the back.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 21,
                     "orderInfo": {
@@ -10738,7 +11100,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -10757,7 +11120,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "ChIJ9XS03Ci2hVQRHK8mAdWtZpE"
                     },
-                    "notes": "Recipients live in a shed next to the house. Please deliver to the main big white house and they will get it from there. Recipients are Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -10767,7 +11130,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -10796,7 +11160,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -10815,7 +11180,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "ChIJ4Tn43FSVhVQRa7VyloYsl9c"
                     },
-                    "notes": "leave boxes on the porch",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 28,
                     "orderInfo": {
@@ -10825,7 +11190,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -10844,7 +11210,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "ChIJH3POzza4hVQRLfEii0cLhAU"
                     },
-                    "notes": "Drive past the field, as you begin to go downhill you will see a yellow trailer on the left. Deliver there.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -10854,7 +11220,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -10873,7 +11240,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "ChIJV82FevbAhVQR7vqWDYWtlhA"
                     },
-                    "notes": "Birch Bay RV Resort - Refer to the map on the main office door if you can't find trailer.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 25,
                     "orderInfo": {
@@ -10883,7 +11250,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -10902,7 +11270,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "ChIJXZYx48jGhVQRubJTNMoXdSM"
                     },
-                    "notes": "Recipient lives in the older house on the property, the one further back. Deliver to the back door, if possible.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 16,
                     "orderInfo": {
@@ -10912,7 +11280,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -10936,7 +11305,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "ChIJExB3Fj_IhVQRMrDlR3KyRA8"
                     },
-                    "notes": "Please deliver to front door and knock. If no one is home, please leave at the back door in the enclosed porch. Two dogs have been reported outside this address. They bark, but are very friendly.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -10946,7 +11315,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -10975,7 +11345,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -10994,7 +11365,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "ChIJDz5XDqy4hVQRo6IUNzJLdxM"
                     },
-                    "notes": "Recipient lives in the Ford Forewind motorhome located in the back left corner of the property. Watch for loose animals (mainly cats) as you drive onto the property.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -11004,7 +11375,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -11023,7 +11395,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "ChIJt2GQiVy4hVQR6Wg3xW3bjpM"
                     },
-                    "notes": "Recipient lives in a blue house in the back, behind the main house. The driveway to their house is just south of the grey house. IF YOU FEEL THREATENED BY THE BARKING DOGS, PLEASE CALL RECIPIENT AND LET TEAM HD KNOW.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -11033,7 +11405,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -11062,7 +11435,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -11081,7 +11455,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "EjI5MjAgQmlyY2ggQmF5IEx5bmRlbiBSZCAjMjksIEx5bmRlbiwgV0EgOTgyNjQsIFVTQSIeGhwKFgoUChIJU8QGEya4hVQRxRRcZDMM3fYSAjI5"
                     },
-                    "notes": "Maberry farm worker housing - Follow the long driveway (Rathbone Rd) off of Birch Bay Lynden Rd to get to apartments. There are two recipients in this unit (Magali and Ester), please deliver both boxes to apartment door. Recipients are Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -11091,7 +11465,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -11110,7 +11485,7 @@
                         "addressLineTwo": "stop-1-6 addressLineTwo",
                         "placeId": "EiQxMTQxIE1hcnkgQXZlLCBCbGFpbmUsIFdBIDk4MjMwLCBVU0EiMRIvChQKEgmLmPfyTMGFVBGRTSDQgKrspRD1CCoUChIJgxBW8kzBhVQRR3L0DHkmZTM"
                     },
-                    "notes": "Deliver to front porch.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 24,
                     "orderInfo": {
@@ -11120,7 +11495,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -11139,7 +11515,7 @@
                         "addressLineTwo": "stop-1-7 addressLineTwo",
                         "placeId": "ChIJPQX8U1TBhVQRanMa8wE2Xs4"
                     },
-                    "notes": "Deliver to front porch.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 22,
                     "orderInfo": {
@@ -11149,7 +11525,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -11178,7 +11555,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -11197,7 +11575,7 @@
                         "addressLineTwo": "stop-1-9 addressLineTwo",
                         "placeId": "ChIJESTaiN3GhVQRs9UJVVXoEk8"
                     },
-                    "notes": "Please deliver to the white trailer, not the pink one. Recipient is Spanish-speaking. **Please let Team HD know if additional directions are necessary.**",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -11207,7 +11585,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -11231,7 +11610,7 @@
                         "addressLineTwo": "stop-2-0 addressLineTwo",
                         "placeId": "ChIJaft7pvu4hVQRT1St14Hd0qc"
                     },
-                    "notes": "Recipient lives in the (B) shop next to the house. Deliver to the front door of the shop or just inside the door in inclement weather.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -11241,7 +11620,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -11260,7 +11640,7 @@
                         "addressLineTwo": "stop-2-1 addressLineTwo",
                         "placeId": "ChIJn2RRgB3EhVQRrM9op5EbeZY"
                     },
-                    "notes": "The recipient's house is behind the yellow house; use the driveway just west of the yellow house's driveway. Beware of wasps living under the hood of the SUV out front. If you cannot identify the house to deliver to, please leave the box in front of the garage doors and call the recipient to tell them where it is.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 17,
                     "orderInfo": {
@@ -11270,7 +11650,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -11289,7 +11670,7 @@
                         "addressLineTwo": "stop-2-2 addressLineTwo",
                         "placeId": "ChIJ5XDfnQHEhVQRmBEP0AYiJtQ"
                     },
-                    "notes": "Green and white single wide. Please deliver to front porch.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 19,
                     "orderInfo": {
@@ -11299,7 +11680,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -11318,7 +11700,7 @@
                         "addressLineTwo": "stop-2-3 addressLineTwo",
                         "placeId": "EjI5MjAgQmlyY2ggQmF5IEx5bmRlbiBSZCAjMTEsIEx5bmRlbiwgV0EgOTgyNjQsIFVTQSIeGhwKFgoUChIJU8QGEya4hVQRxRRcZDMM3fYSAjEx"
                     },
-                    "notes": "Maberry farm worker housing - Follow the long driveway (Rathbone Rd) off of Birch Bay Lynden Rd to get to apartments. Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -11328,7 +11710,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -11347,7 +11730,7 @@
                         "addressLineTwo": "stop-2-4 addressLineTwo",
                         "placeId": "ChIJlQrThnPAhVQRTtYYb-80JYU"
                     },
-                    "notes": "Please deliver to the back door. Take the ramp up and leave the box in the sun porch, if possible.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 27,
                     "orderInfo": {
@@ -11357,7 +11740,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -11376,7 +11760,7 @@
                         "addressLineTwo": "stop-2-5 addressLineTwo",
                         "placeId": "EiQxMTcxIE1hcnkgQXZlLCBCbGFpbmUsIFdBIDk4MjMwLCBVU0EiMRIvChQKEgmLmPfyTMGFVBENKHR3elLmmBCTCSoUChIJgxBW8kzBhVQRR3L0DHkmZTM"
                     },
-                    "notes": "SeaMist Townhouses",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 23,
                     "orderInfo": {
@@ -11386,7 +11770,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -11405,7 +11790,7 @@
                         "addressLineTwo": "stop-2-6 addressLineTwo",
                         "placeId": "ChIJ3d9RUIy3hVQRY2YO9QVWLS8"
                     },
-                    "notes": "House is yellow and there are no numbers on it. Recipient is Mixteco & Spanish speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -11415,7 +11800,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -11434,7 +11820,7 @@
                         "addressLineTwo": "stop-2-7 addressLineTwo",
                         "placeId": "ChIJYczCzcu5hVQRD5WOhUboujI"
                     },
-                    "notes": "Address is marked with a blue address post at mailbox. Stay right on the shared driveway and drive down the gravel road. There are multiple trailers on the property, look for the one near a green tent with a gray headless manikin in front of it. Deliver to the top of the brown wooden ramp by the trailer door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -11444,7 +11830,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -11463,7 +11850,7 @@
                         "addressLineTwo": "stop-2-8 addressLineTwo",
                         "placeId": "EjI5MjAgQmlyY2ggQmF5IEx5bmRlbiBSZCAjMjksIEx5bmRlbiwgV0EgOTgyNjQsIFVTQSIeGhwKFgoUChIJU8QGEya4hVQRxRRcZDMM3fYSAjI5"
                     },
-                    "notes": "Maberry farm worker housing - Follow the long driveway (Rathbone Rd) off of Birch Bay Lynden Rd to get to apartments. There are two recipients in this unit (Magali and Ester), please deliver both boxes to apartment door. Recipients are Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -11473,7 +11860,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/QBJtzxuw5xhyS4ud8lrV",
                     "route": {
@@ -11499,7 +11887,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "ChIJzz_Gj4ehhVQRkYV5T7AB-9Y"
                     },
-                    "notes": "Varsity Village* - Please knock. If she doesn't bring box in right away, crows get into the meat.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -11509,7 +11897,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/R2PHtpeQyr7Q2ITSGC0J",
                     "route": {
@@ -11528,7 +11917,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "ChIJ3xiJnYehhVQRCxfS8Fs1reU"
                     },
-                    "notes": "Varsity Village*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -11538,7 +11927,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/R2PHtpeQyr7Q2ITSGC0J",
                     "route": {
@@ -11557,7 +11947,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "Eig5MjcgMjFzdCBTdCBkLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh0aGwoWChQKEgkveD3rLqKFVBGh-u3SG4S6MBIBZA"
                     },
-                    "notes": "Hamlet Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -11567,7 +11957,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/R2PHtpeQyr7Q2ITSGC0J",
                     "route": {
@@ -11586,7 +11977,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "EikxODEwIDE2dGggU3QgYSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIdGhsKFgoUChIJdas6wCCihVQRvJORwZ7ghhASAWE"
                     },
-                    "notes": "Parkway Homes",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 20,
                     "orderInfo": {
@@ -11596,7 +11987,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/R2PHtpeQyr7Q2ITSGC0J",
                     "route": {
@@ -11615,7 +12007,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "EisyNDIxIERvbm92YW4gQXZlLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIjESLwoUChIJd04LkoehhVQRpuLGbw0E60MQ9RIqFAoSCV-0rPiHoYVUEdTm9WTltpMS"
                     },
-                    "notes": "Varsity Village*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -11625,7 +12017,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/R2PHtpeQyr7Q2ITSGC0J",
                     "route": {
@@ -11644,7 +12037,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "EikxODIwIDE2dGggU3QgYiwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIdGhsKFgoUChIJP8XyviCihVQRGqgkhWkxsdkSAWI"
                     },
-                    "notes": "Parkway Homes",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 17,
                     "orderInfo": {
@@ -11654,7 +12047,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/R2PHtpeQyr7Q2ITSGC0J",
                     "route": {
@@ -11673,7 +12067,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "ChIJkwk4jYehhVQRvn5rLTUXgh4"
                     },
-                    "notes": "Varsity Village* - Recipient's unit is fairly close to the WTA bus stop.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -11683,7 +12077,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/R2PHtpeQyr7Q2ITSGC0J",
                     "route": {
@@ -11702,7 +12097,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -11710,7 +12105,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/R2PHtpeQyr7Q2ITSGC0J",
                     "route": {
@@ -11729,7 +12125,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "ChIJEeLUeXKhhVQRHbndEOJmuzU"
                     },
-                    "notes": "Varsity Village*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -11739,7 +12135,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/R2PHtpeQyr7Q2ITSGC0J",
                     "route": {
@@ -11758,7 +12155,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "EikxMTI5IDIybmQgU3QgYSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIdGhsKFgoUChIJJfyyHSmihVQRMIyo6uLE52kSAWE"
                     },
-                    "notes": "Please place box to the side of the entrance, in the shade, if possible.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -11768,7 +12165,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/R2PHtpeQyr7Q2ITSGC0J",
                     "route": {
@@ -11792,7 +12190,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "ChIJKzCGc4ehhVQReJFqX5YwFss"
                     },
-                    "notes": "Varsity Village* - Please put the PROTEIN UNDER THE BOX to deter crows from carrying it away.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -11802,7 +12200,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/R2PHtpeQyr7Q2ITSGC0J",
                     "route": {
@@ -11821,7 +12220,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "ChIJGRQf4CujhVQRUPBippzEl_g"
                     },
-                    "notes": "Parkway Homes",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 18,
                     "orderInfo": {
@@ -11831,7 +12230,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/R2PHtpeQyr7Q2ITSGC0J",
                     "route": {
@@ -11850,7 +12250,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "ChIJb2iuG_OhhVQRmqoibGCHzZU"
                     },
-                    "notes": "Varsity Village*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -11860,7 +12260,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/R2PHtpeQyr7Q2ITSGC0J",
                     "route": {
@@ -11879,7 +12280,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "ChIJDYptj4ehhVQRm-M67HE0nIs"
                     },
-                    "notes": "Varsity Village*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -11889,7 +12290,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/R2PHtpeQyr7Q2ITSGC0J",
                     "route": {
@@ -11908,7 +12310,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "ChIJI1fEyIehhVQRK9cV9mo4XIA"
                     },
-                    "notes": "South End Mobile Estates",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -11918,7 +12320,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/R2PHtpeQyr7Q2ITSGC0J",
                     "route": {
@@ -11937,7 +12340,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "EisyNDIzIERvbm92YW4gQXZlLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIjESLwoUChIJd04LkoehhVQRpuLGbw0E60MQ9xIqFAoSCV-0rPiHoYVUEdTm9WTltpMS"
                     },
-                    "notes": "Varsity Village*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -11947,7 +12350,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/R2PHtpeQyr7Q2ITSGC0J",
                     "route": {
@@ -11966,7 +12370,7 @@
                         "addressLineTwo": "stop-1-6 addressLineTwo",
                         "placeId": "ChIJnXQUsIihhVQRogDQIJzqKbc"
                     },
-                    "notes": "Parkway Village - Please deliver to carport.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 16,
                     "orderInfo": {
@@ -11976,7 +12380,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/R2PHtpeQyr7Q2ITSGC0J",
                     "route": {
@@ -11995,7 +12400,7 @@
                         "addressLineTwo": "stop-1-7 addressLineTwo",
                         "placeId": "EisyNDc1IERvbm92YW4gQXZlLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIjESLwoUChIJ9_IjmoehhVQRdoTJFq-PRQAQqxMqFAoSCV-0rPiHoYVUEdTm9WTltpMS"
                     },
-                    "notes": "Varsity Village*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -12005,7 +12410,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/R2PHtpeQyr7Q2ITSGC0J",
                     "route": {
@@ -12024,7 +12430,7 @@
                         "addressLineTwo": "stop-1-8 addressLineTwo",
                         "placeId": "EiwyMDAxIEhhcnJpcyBBdmUgZSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIdGhsKFgoUChIJpwFHmCiihVQRV26dEnSNtTQSAWU"
                     },
-                    "notes": "Complex is 2nd building from Super Duper Teriyaki. Recipient is deaf, please text if you need to get ahold of them.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -12034,7 +12440,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/R2PHtpeQyr7Q2ITSGC0J",
                     "route": {
@@ -12053,7 +12460,7 @@
                         "addressLineTwo": "stop-1-9 addressLineTwo",
                         "placeId": "EikxODA4IDE2dGggU3QgYiwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIdGhsKFgoUChIJXQeYwSCihVQR_kqHre4W6U4SAWI"
                     },
-                    "notes": "Parkway Homes",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 19,
                     "orderInfo": {
@@ -12063,7 +12470,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/R2PHtpeQyr7Q2ITSGC0J",
                     "route": {
@@ -12087,7 +12495,7 @@
                         "addressLineTwo": "stop-2-0 addressLineTwo",
                         "placeId": "EisyNTYzIERvbm92YW4gQXZlLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIjESLwoUChIJszEin4ehhVQR1_w_IVpBkCMQgxQqFAoSCV-0rPiHoYVUEdTm9WTltpMS"
                     },
-                    "notes": "Varsity Village*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -12097,7 +12505,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/R2PHtpeQyr7Q2ITSGC0J",
                     "route": {
@@ -12133,7 +12542,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/SWrNVm5pPxcbCWVdppcI",
                     "route": {
@@ -12162,7 +12572,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/SWrNVm5pPxcbCWVdppcI",
                     "route": {
@@ -12191,7 +12602,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/SWrNVm5pPxcbCWVdppcI",
                     "route": {
@@ -12210,7 +12622,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "EjAyOTExIFcgSWxsaW5vaXMgU3QgIzIsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHRobChYKFAoSCav6aNsRo4VUEeoB9lpVIplQEgEy"
                     },
-                    "notes": "Deliver to back door which faces W Illinois St.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -12220,7 +12632,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/SWrNVm5pPxcbCWVdppcI",
                     "route": {
@@ -12239,7 +12652,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -12247,7 +12660,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/SWrNVm5pPxcbCWVdppcI",
                     "route": {
@@ -12266,7 +12680,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "ChIJgXHqTWujhVQRy6Lq_xjVg1o"
                     },
-                    "notes": "Brown house, white trim. The driveway won't accommodate low riding vehicles due to the giant tree's roots upearthing the concrete. You may park across the yard and walk across the grass. The dog inside will bark if he sees you, but he can't get out.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -12276,7 +12690,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/SWrNVm5pPxcbCWVdppcI",
                     "route": {
@@ -12295,7 +12710,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "EjAyOTExIFcgSWxsaW5vaXMgU3QgIzcsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHRobChYKFAoSCav6aNsRo4VUEeoB9lpVIplQEgE3"
                     },
-                    "notes": "Complex is across from BTC. This recipient does not have a back door, deliver to front door which faces front yard on Nome St.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -12305,7 +12720,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/SWrNVm5pPxcbCWVdppcI",
                     "route": {
@@ -12334,7 +12750,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/SWrNVm5pPxcbCWVdppcI",
                     "route": {
@@ -12353,7 +12770,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "EjMyNzMwIFcgTWFwbGV3b29kIEF2ZSAjMTUsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiORo3CjESLwoUChIJw8dSA2ujhVQRmlTTEEchmxQQqhUqFAoSCWFBVihHo4VUEQUaEqCaErvzEgIxNQ"
                     },
-                    "notes": "Crestwood Manor Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -12363,7 +12780,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/SWrNVm5pPxcbCWVdppcI",
                     "route": {
@@ -12392,7 +12810,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/SWrNVm5pPxcbCWVdppcI",
                     "route": {
@@ -12416,7 +12835,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "ChIJBSuHyQ-jhVQR35MxTNBoJK8"
                     },
-                    "notes": "Property is surrounded by a large fence. Please deliver box outside the fence so the dog remains inside.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -12426,7 +12845,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/SWrNVm5pPxcbCWVdppcI",
                     "route": {
@@ -12462,7 +12882,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/Sy8X9uOrQO3qYoXvNxqg",
                     "route": {
@@ -12481,7 +12902,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "ChIJr1W7wHWkhVQR5kqTP-mWLuU"
                     },
-                    "notes": "Hillside Homes - Green townhouse that is not visible from Yew St.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -12491,7 +12912,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/Sy8X9uOrQO3qYoXvNxqg",
                     "route": {
@@ -12510,7 +12932,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "EiYyMTc2IFlldyBTdCwgQmVsbGluZ2hhbSwgV0EgOTgyMjksIFVTQSIxEi8KFAoSCS12YuB1pIVUERmnzQtlGg5VEIARKhQKEgkfYGFTdqSFVBEvc3hUspYVlg"
                     },
-                    "notes": "Hillside Homes",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -12520,7 +12942,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/Sy8X9uOrQO3qYoXvNxqg",
                     "route": {
@@ -12539,7 +12962,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -12547,7 +12970,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/Sy8X9uOrQO3qYoXvNxqg",
                     "route": {
@@ -12566,7 +12990,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "EiYyMTQyIFlldyBTdCwgQmVsbGluZ2hhbSwgV0EgOTgyMjksIFVTQSIxEi8KFAoSCS12YuB1pIVUERmnzQtlGg5VEN4QKhQKEgkfYGFTdqSFVBEvc3hUspYVlg"
                     },
-                    "notes": "Hillside Homes",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -12576,7 +13000,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/Sy8X9uOrQO3qYoXvNxqg",
                     "route": {
@@ -12595,7 +13020,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "ChIJUf4CAIqjhVQRYoeVPBE1L08"
                     },
-                    "notes": "Recipient's side of the duplex is on the right, with a yellow door. Please ring doorbell and place on doorstep.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -12605,7 +13030,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/Sy8X9uOrQO3qYoXvNxqg",
                     "route": {
@@ -12634,7 +13060,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/Sy8X9uOrQO3qYoXvNxqg",
                     "route": {
@@ -12653,7 +13080,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "ChIJ22t_NHGkhVQR-B7Eqzfkg1w"
                     },
-                    "notes": "There are 2 recipients at this address. Eric (LA box) and Joseph (Basic box) both get a delivery weekly.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -12663,7 +13090,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/Sy8X9uOrQO3qYoXvNxqg",
                     "route": {
@@ -12682,7 +13110,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "ChIJ22t_NHGkhVQR-B7Eqzfkg1w"
                     },
-                    "notes": "There are 2 recipients at this address. Eric (LA box) and Joseph (Basic box) both get a delivery weekly.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -12692,7 +13120,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/Sy8X9uOrQO3qYoXvNxqg",
                     "route": {
@@ -12711,7 +13140,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "ChIJM7SllXCkhVQRuIJvyYUq9gA"
                     },
-                    "notes": "Enter alley to deliver to the trailer behind the brown house",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -12721,7 +13150,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/Sy8X9uOrQO3qYoXvNxqg",
                     "route": {
@@ -12755,7 +13185,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/Sy8X9uOrQO3qYoXvNxqg",
                     "route": {
@@ -12784,7 +13215,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/Sy8X9uOrQO3qYoXvNxqg",
                     "route": {
@@ -12803,7 +13235,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "EiYyMTgyIFlldyBTdCwgQmVsbGluZ2hhbSwgV0EgOTgyMjksIFVTQSIxEi8KFAoSCS12YuB1pIVUERmnzQtlGg5VEIYRKhQKEgkfYGFTdqSFVBEvc3hUspYVlg"
                     },
-                    "notes": "Hillside Homes",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -12813,7 +13245,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/Sy8X9uOrQO3qYoXvNxqg",
                     "route": {
@@ -12839,7 +13272,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "EjAzNjE1IEJlbm5ldHQgRHIgaSAxMzcsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiIRofChYKFAoSCUtW6bI5o4VUEXYO1pyewMwBEgVpIDEzNw"
                     },
-                    "notes": "Northbrook Place Apartments - Building I (as in India)",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -12849,7 +13282,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/VjOdrtu6j0xc6MGYLOZt",
                     "route": {
@@ -12868,7 +13302,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "EjAzNjE1IEJlbm5ldHQgRHIgZSAyMjEsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiIRofChYKFAoSCUtW6bI5o4VUEXYO1pyewMwBEgVlIDIyMQ"
                     },
-                    "notes": "Northbrook Place Apartments - Building E",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -12878,7 +13312,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/VjOdrtu6j0xc6MGYLOZt",
                     "route": {
@@ -12897,7 +13332,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "EjAzNjE1IEJlbm5ldHQgRHIgYiAxMDgsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiIRofChYKFAoSCUtW6bI5o4VUEXYO1pyewMwBEgViIDEwOA"
                     },
-                    "notes": "Northbrook Place Apartments - Building B",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -12907,7 +13342,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/VjOdrtu6j0xc6MGYLOZt",
                     "route": {
@@ -12926,7 +13362,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "ChIJuUY0azmjhVQR6dbAtfB7yZs"
                     },
-                    "notes": "If driving south on Bennett, take the first driveway on the right after McCleod Rd (where the 'Open Storage Availble' sign is posted). Deliver to the green house on the immediate right.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -12936,7 +13372,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/VjOdrtu6j0xc6MGYLOZt",
                     "route": {
@@ -12955,7 +13392,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "ChIJ19LZEkqjhVQR95R0lwFs-c8"
                     },
-                    "notes": "Recipients are in the white house with green trim located to the right of the Legacy Motoring building. The house number may not be visible. Set GPS to Bellingham Pawn (4161 Bennett Dr) if you're having trouble finding recipient's address.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -12965,7 +13402,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/VjOdrtu6j0xc6MGYLOZt",
                     "route": {
@@ -12984,7 +13422,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "EjAzNjE1IEJlbm5ldHQgRHIgZyAyMjcsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiIRofChYKFAoSCUtW6bI5o4VUEXYO1pyewMwBEgVnIDIyNw"
                     },
-                    "notes": "Northbrook Place Apartments - Building G",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -12994,7 +13432,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/VjOdrtu6j0xc6MGYLOZt",
                     "route": {
@@ -13013,7 +13452,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "EjAzNjE1IEJlbm5ldHQgRHIgZiAxMjUsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiIRofChYKFAoSCUtW6bI5o4VUEXYO1pyewMwBEgVmIDEyNQ"
                     },
-                    "notes": "Northbrook Place Apartments - Building F. There is a lockbox on recipient's door for emergency purposes only. She is still living there and still needs deliveries.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -13023,7 +13462,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/VjOdrtu6j0xc6MGYLOZt",
                     "route": {
@@ -13042,7 +13482,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "EjAzNjE1IEJlbm5ldHQgRHIgZiAzMjMsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiIRofChYKFAoSCUtW6bI5o4VUEXYO1pyewMwBEgVmIDMyMw"
                     },
-                    "notes": "Northbrook Place Apartments - Building F",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -13052,7 +13492,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/VjOdrtu6j0xc6MGYLOZt",
                     "route": {
@@ -13071,7 +13512,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "EjAzNjE1IEJlbm5ldHQgRHIgaCAxMzEsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiIRofChYKFAoSCUtW6bI5o4VUEXYO1pyewMwBEgVoIDEzMQ"
                     },
-                    "notes": "Northbrook Place Apartments - Building H. Recipient's unit is in the farthest back corner. Please place delivery on the box behind the bikes.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -13081,7 +13522,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/VjOdrtu6j0xc6MGYLOZt",
                     "route": {
@@ -13100,7 +13542,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -13108,7 +13550,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/VjOdrtu6j0xc6MGYLOZt",
                     "route": {
@@ -13132,7 +13575,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "EjAzNjE1IEJlbm5ldHQgRHIgaSAyMzgsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiIRofChYKFAoSCUtW6bI5o4VUEXYO1pyewMwBEgVpIDIzOA"
                     },
-                    "notes": "Northbrook Place Apartments - Building I (as in India)",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -13142,7 +13585,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/VjOdrtu6j0xc6MGYLOZt",
                     "route": {
@@ -13161,7 +13605,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "EjAzNjE1IEJlbm5ldHQgRHIgaCAyMzEsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiIRofChYKFAoSCUtW6bI5o4VUEXYO1pyewMwBEgVoIDIzMQ"
                     },
-                    "notes": "Northbrook Place Apartments - Building H",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -13171,7 +13615,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/VjOdrtu6j0xc6MGYLOZt",
                     "route": {
@@ -13190,7 +13635,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "EjAzNjE1IEJlbm5ldHQgRHIgZyAyMjgsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiIRofChYKFAoSCUtW6bI5o4VUEXYO1pyewMwBEgVnIDIyOA"
                     },
-                    "notes": "Northbrook Place Apartments - Building G",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -13200,7 +13645,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/VjOdrtu6j0xc6MGYLOZt",
                     "route": {
@@ -13219,7 +13665,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "EjAzNjE1IEJlbm5ldHQgRHIgaSAxMzgsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiIRofChYKFAoSCUtW6bI5o4VUEXYO1pyewMwBEgVpIDEzOA"
                     },
-                    "notes": "Northbrook Place Apartments - Building I (as in India)",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -13229,7 +13675,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/VjOdrtu6j0xc6MGYLOZt",
                     "route": {
@@ -13248,7 +13695,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "Ei4zOTM5IEJlbm5ldHQgRHIgIzQyLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh4aHAoWChQKEgm_HkXYN6OFVBEtKkRr_OivcRICNDI"
                     },
-                    "notes": "Bellingham RV Park - Recipient's trailer number is located on a power box.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -13258,7 +13705,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/VjOdrtu6j0xc6MGYLOZt",
                     "route": {
@@ -13277,7 +13725,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "EjAzNjE1IEJlbm5ldHQgRHIgYiAyMDcsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiIRofChYKFAoSCUtW6bI5o4VUEXYO1pyewMwBEgViIDIwNw"
                     },
-                    "notes": "Northbrook Place Apartments - Building B",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -13287,7 +13735,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/VjOdrtu6j0xc6MGYLOZt",
                     "route": {
@@ -13313,7 +13762,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "Eik5MDkgMjJuZCBTdCAjOSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIdGhsKFgoUChIJfZwoKCyihVQRGlNz_XW2bV8SATk"
                     },
-                    "notes": "Recipient's unit is in the building on the left at the end of parking lot, on the second floor. Apartment door faces the dumpster. Please deliver to the top of the stairs.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -13323,7 +13772,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/WxozpfS6v5cSToxVuT2Q",
                     "route": {
@@ -13342,7 +13792,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "Eio4MTYgMjR0aCBTdCAjMTAsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHhocChYKFAoSCUW_8UgsooVUEWDQRzYV86t7EgIxMA"
                     },
-                    "notes": "Beech Apartments - On the corner of 24th and Taylor Ave. The building's parking lot is on the north end (closer to Taylor). Use the ramp to access apartments.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -13352,7 +13802,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/WxozpfS6v5cSToxVuT2Q",
                     "route": {
@@ -13371,7 +13822,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "EiwxMDIwIDI0dGggU3QgIzIwMywgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJgdd-WimihVQR9AFl1lm_thwSAzIwMw"
                     },
-                    "notes": "Rhododendron Court Apartments - Building 1020 is the one on the left when you enter from 24th St. Recipient's unit is located on the farthest side of the building (closest to the dumpsters) and up the stairs.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -13381,7 +13832,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/WxozpfS6v5cSToxVuT2Q",
                     "route": {
@@ -13400,7 +13852,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "Ei4yNjE0IERvdWdsYXMgQXZlICMzLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh0aGwoWChQKEglpQw6XK6KFVBFxChzGG8ptfxIBMw"
                     },
-                    "notes": "There are two recipients at this address - Mathew and Dezmond. Please deliver both boxes to apartment door and DO NOT KNOCK.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -13410,7 +13862,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/WxozpfS6v5cSToxVuT2Q",
                     "route": {
@@ -13429,7 +13882,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -13437,7 +13890,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/WxozpfS6v5cSToxVuT2Q",
                     "route": {
@@ -13456,7 +13910,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "Eig5MzIgMjV0aCBTdCBhLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh0aGwoWChQKEgkXlFkJLKKFVBHp1Cx_hHxuAxIBYQ"
                     },
-                    "notes": "Look for the house on the corner of 25th and Douglas Ave. Access the carport from Douglas and deliver to the door underneath.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -13466,7 +13920,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/WxozpfS6v5cSToxVuT2Q",
                     "route": {
@@ -13485,7 +13940,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "EiwxMDI1IDIzcmQgU3QgIzIwMywgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJo_KxTymihVQRDcsjgt0BbF4SAzIwMw"
                     },
-                    "notes": "Apartment is located in back of the building. Alternative phone number is 206-561-3889.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -13495,7 +13950,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/WxozpfS6v5cSToxVuT2Q",
                     "route": {
@@ -13514,7 +13970,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "EjcyMzAwIEJpbGwgTWNEb25hbGQgUGt3eSAjMTA1LCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgkn9LJMLKKFVBHHNMHM1S3Y2RIDMTA1"
                     },
-                    "notes": "Viking Gardens Apartments - Apartment building access is at the dead end of 24th St. Unit is in the building to the right at the dead end. There are two recipients at this address (Emilee and Juleyana), please deliver both boxes to the door and knock.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -13524,7 +13980,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/WxozpfS6v5cSToxVuT2Q",
                     "route": {
@@ -13543,7 +14000,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "Ei4yMzAzIFRheWxvciBBdmUgIzE5LCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh4aHAoWChQKEgkpSRM2LKKFVBESP9olnNPVchICMTk"
                     },
-                    "notes": "Building and parking lot are accessed from Taylor Ave off of 24th St. Please ring doorbell when making delivery.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -13553,7 +14010,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/WxozpfS6v5cSToxVuT2Q",
                     "route": {
@@ -13572,7 +14030,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "Eik4MTYgMjR0aCBTdCAjNSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIdGhsKFgoUChIJRb_xSCyihVQRYNBHNhXzq3sSATU"
                     },
-                    "notes": "Beech Apartments - On the corner of 24th and Taylor Ave. The building's parking lot is on the north end (closer to Taylor). Use the ramp to access apartments. Please ring doorbell. Do not be alarmed by loud dog barking inside.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -13582,7 +14040,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/WxozpfS6v5cSToxVuT2Q",
                     "route": {
@@ -13606,7 +14065,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "EjAyMjExIERvdWdsYXMgQXZlICMzMDEsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHxodChYKFAoSCf3sD6QuooVUEVIKobuJhHz7EgMzMDE"
                     },
-                    "notes": "Alexandra Apartments - Take the road off Douglas that's just west of JJ's Food Mart. You'll see a parking garage area and then a road directly afterwards. Recipient suggests taking the road after the garage and parking there.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -13616,7 +14075,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/WxozpfS6v5cSToxVuT2Q",
                     "route": {
@@ -13635,7 +14095,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "EjcyMzAwIEJpbGwgTWNEb25hbGQgUGt3eSAjMTA1LCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgkn9LJMLKKFVBHHNMHM1S3Y2RIDMTA1"
                     },
-                    "notes": "Viking Gardens Apartments - Apartment building access is at the dead end of 24th St. Unit is in the building to the right at the dead end. There are two recipients at this address (Emilee and Juleyana), please deliver both boxes to the door and knock.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -13645,7 +14105,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/WxozpfS6v5cSToxVuT2Q",
                     "route": {
@@ -13664,7 +14125,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "EioxMDIxIDI0dGggU3QgIzEsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHRobChYKFAoSCc2eyfwrooVUEY_DQrR6RIcVEgEx"
                     },
-                    "notes": "The Fremont - Deliver to porch.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -13674,7 +14135,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/WxozpfS6v5cSToxVuT2Q",
                     "route": {
@@ -13693,7 +14155,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "Ei4yNjE0IERvdWdsYXMgQXZlICMzLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh0aGwoWChQKEglpQw6XK6KFVBFxChzGG8ptfxIBMw"
                     },
-                    "notes": "There are two recipients at this address - Mathew and Dezmond. Please deliver both boxes to apartment door and DO NOT KNOCK.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -13703,7 +14165,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/WxozpfS6v5cSToxVuT2Q",
                     "route": {
@@ -13722,7 +14185,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "EiwxMDExIDIzcmQgU3QgIzEwMSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJQ1ezrC6ihVQR2rxXWxPTqQYSAzEwMQ"
                     },
-                    "notes": "Recipient's door is on the side of the apartment complex behind the stairs.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -13732,7 +14195,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/WxozpfS6v5cSToxVuT2Q",
                     "route": {
@@ -13751,7 +14215,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "Eik4MTYgMjR0aCBTdCAjNywgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIdGhsKFgoUChIJRb_xSCyihVQRYNBHNhXzq3sSATc"
                     },
-                    "notes": "Beech Apartments - On the corner of 24th and Taylor Ave. The building's parking lot is on the north end (closer to Taylor). Use the ramp to access apartments.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -13761,7 +14225,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/WxozpfS6v5cSToxVuT2Q",
                     "route": {
@@ -13787,7 +14252,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "EjAzMjIwIE9ybGVhbnMgU3QgYiAyMDQsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiIRofChYKFAoSCalY-t-ApIVUEUFBxd9NjaoIEgViIDIwNA"
                     },
-                    "notes": "Orleans Place Apartments - B units are in the 3230 building, the second one in the complex.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -13797,7 +14262,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/YUsJTuxgJjdZDRh0UXM7",
                     "route": {
@@ -13816,7 +14282,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "Ei8zMjEwIE9ybGVhbnMgU3QgIzIwNiwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJ0ebB54CkhVQRxz298vGkOJwSAzIwNg"
                     },
-                    "notes": "Deer Run Terrace Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -13826,7 +14292,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/YUsJTuxgJjdZDRh0UXM7",
                     "route": {
@@ -13845,7 +14312,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "EjAzMjIwIE9ybGVhbnMgU3QgYiAxMDEsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiIRofChYKFAoSCalY-t-ApIVUEUFBxd9NjaoIEgViIDEwMQ"
                     },
-                    "notes": "Orleans Place Apartments - B units are in the 3230 building, the second one in the complex.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -13855,7 +14322,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/YUsJTuxgJjdZDRh0UXM7",
                     "route": {
@@ -13874,7 +14342,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "Ei8zMjEwIE9ybGVhbnMgU3QgIzMxNCwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJ0ebB54CkhVQRxz298vGkOJwSAzMxNA"
                     },
-                    "notes": "Deer Run Terrace Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -13884,7 +14352,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/YUsJTuxgJjdZDRh0UXM7",
                     "route": {
@@ -13903,7 +14372,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "Ei8zMjEwIE9ybGVhbnMgU3QgIzIwNywgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJ0ebB54CkhVQRxz298vGkOJwSAzIwNw"
                     },
-                    "notes": "Deer Run Terrace Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -13913,7 +14382,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/YUsJTuxgJjdZDRh0UXM7",
                     "route": {
@@ -13932,7 +14402,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "EjAzMjIwIE9ybGVhbnMgU3QgYSAyMDMsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiIRofChYKFAoSCalY-t-ApIVUEUFBxd9NjaoIEgVhIDIwMw"
                     },
-                    "notes": "Orleans Place Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -13942,7 +14412,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/YUsJTuxgJjdZDRh0UXM7",
                     "route": {
@@ -13961,7 +14432,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "EiwzMTY3IFN0dWRpbyBMbiAjOSwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSI4GjYKMRIvChQKEgmtnL28gKSFVBELZTtEJCNlkhDfGCoUChIJn5A_vICkhVQRD2MsP5evia8SATk"
                     },
-                    "notes": "Studio Lane Apartments - There is a lot of theft in this complex, PLEASE CALL RECIPIENT WHEN MAKING THE DELIVERY. Recipient's deck is just to the left of the fire hydrant, with one chair on it and a bamboo windchime. Please deliver to recipient's deck or call him when you get there and he will come out to claim his box.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -13971,7 +14442,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/YUsJTuxgJjdZDRh0UXM7",
                     "route": {
@@ -13990,7 +14462,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "Ei0zMTYzIFN0dWRpbyBMbiAjMjMsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiHhocChYKFAoSCTf7Kb2ApIVUESR46xhDzTPIEgIyMw"
                     },
-                    "notes": "Studio Lane Apartments - Recipient is on the second floor.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -14000,7 +14472,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/YUsJTuxgJjdZDRh0UXM7",
                     "route": {
@@ -14019,7 +14492,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "EjAzMjIwIE9ybGVhbnMgU3QgYiAxMDIsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiIRofChYKFAoSCalY-t-ApIVUEUFBxd9NjaoIEgViIDEwMg"
                     },
-                    "notes": "Orleans Place Apartments - B units are in the 3230 building, the second one in the complex.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -14029,7 +14502,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/YUsJTuxgJjdZDRh0UXM7",
                     "route": {
@@ -14048,7 +14522,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "Ei8zMjEwIE9ybGVhbnMgU3QgIzIxMCwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJ0ebB54CkhVQRxz298vGkOJwSAzIxMA"
                     },
-                    "notes": "Deer Run Terrace Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -14058,7 +14532,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/YUsJTuxgJjdZDRh0UXM7",
                     "route": {
@@ -14082,7 +14557,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "EjAzMjIwIE9ybGVhbnMgU3QgYSAzMDMsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiIRofChYKFAoSCalY-t-ApIVUEUFBxd9NjaoIEgVhIDMwMw"
                     },
-                    "notes": "Orleans Place Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -14092,7 +14567,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/YUsJTuxgJjdZDRh0UXM7",
                     "route": {
@@ -14111,7 +14587,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -14119,7 +14595,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/YUsJTuxgJjdZDRh0UXM7",
                     "route": {
@@ -14138,7 +14615,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "Ei8zMjEwIE9ybGVhbnMgU3QgIzIwNSwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJ0ebB54CkhVQRxz298vGkOJwSAzIwNQ"
                     },
-                    "notes": "Deer Run Terrace Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -14148,7 +14625,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/YUsJTuxgJjdZDRh0UXM7",
                     "route": {
@@ -14167,7 +14645,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "Ei8zMjEwIE9ybGVhbnMgU3QgIzIxNCwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJ0ebB54CkhVQRxz298vGkOJwSAzIxNA"
                     },
-                    "notes": "Deer Run Terrace Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -14177,7 +14655,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/YUsJTuxgJjdZDRh0UXM7",
                     "route": {
@@ -14196,7 +14675,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "Ei8zMjEwIE9ybGVhbnMgU3QgIzEwNywgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJ0ebB54CkhVQRxz298vGkOJwSAzEwNw"
                     },
-                    "notes": "Deer Run Terrace Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -14206,7 +14685,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/YUsJTuxgJjdZDRh0UXM7",
                     "route": {
@@ -14232,7 +14712,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "ChIJk4JxPXmkhVQRxeVagCldk5E"
                     },
-                    "notes": "Recipient's house is up a long driveway, behind 2844 Undine St.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -14242,7 +14722,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/Ye94X1pXOYuMKn4ZLbYf",
                     "route": {
@@ -14261,7 +14742,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "ChIJH7CoaX-khVQR6CEMMQMthn8"
                     },
-                    "notes": "The road to access recipient's address is on the north side of E Illinois St, between Pacific and Racine. Look for address numbers posted on a wooden fence at the entrance to the road. Recipient lives in the house on the right as you come up the road, you'll see the address numbers posted on the gate. Please leave box under the green awning. TEXT recipient if you have questions, please DO NOT call.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -14271,7 +14752,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/Ye94X1pXOYuMKn4ZLbYf",
                     "route": {
@@ -14300,7 +14782,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/Ye94X1pXOYuMKn4ZLbYf",
                     "route": {
@@ -14319,7 +14802,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "ChIJIT1uDoWjhVQR-9MUT5Yfypw"
                     },
-                    "notes": "There are two recipients at this address - Joyce and Blaze. Leave both boxes (one for each) at the front door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -14329,7 +14812,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/Ye94X1pXOYuMKn4ZLbYf",
                     "route": {
@@ -14348,7 +14832,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -14356,7 +14840,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/Ye94X1pXOYuMKn4ZLbYf",
                     "route": {
@@ -14375,7 +14860,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "ChIJ1dr7xYajhVQRH-dmcvahRa4"
                     },
-                    "notes": "Please deliver to front steps.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -14385,7 +14870,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/Ye94X1pXOYuMKn4ZLbYf",
                     "route": {
@@ -14404,7 +14890,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "ChIJKbhoX4ejhVQRjIiTCvLZnSQ"
                     },
-                    "notes": "House is tucked away at the deadend of Racine St off of E Maryland. Turn at the row of white mailboxes and recipient's house is the one toward the back right, next to the tall brown fence.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -14414,7 +14900,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/Ye94X1pXOYuMKn4ZLbYf",
                     "route": {
@@ -14443,7 +14930,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/Ye94X1pXOYuMKn4ZLbYf",
                     "route": {
@@ -14462,7 +14950,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "ChIJIT1uDoWjhVQR-9MUT5Yfypw"
                     },
-                    "notes": "There are two recipients at this address - Joyce and Blaze. Leave both boxes (one for each) at the front door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -14472,7 +14960,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/Ye94X1pXOYuMKn4ZLbYf",
                     "route": {
@@ -14491,7 +14980,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "EisyNzA5IE1vb3JlIFN0ICMzLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh0aGwoWChQKEgmHYWpFgaOFVBFu8iBVebsT-RIBMw"
                     },
-                    "notes": "Google Maps will try to take you to Moore St via E North St, DISREGARD THESE DIRECTIONS. Instead, access Moore St from E Maryland St. Deliver to apartment door and knock.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -14501,7 +14990,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/Ye94X1pXOYuMKn4ZLbYf",
                     "route": {
@@ -14525,7 +15015,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "EisyNjIwIFVuZGluZSBTdCBiLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh0aGwoWChQKEgmTy1RGeKSFVBHd1SkCy0Yt-hIBYg"
                     },
-                    "notes": "Green duplex, Please deliver to the door marked with a B.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -14535,7 +15025,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/Ye94X1pXOYuMKn4ZLbYf",
                     "route": {
@@ -14564,7 +15055,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/Ye94X1pXOYuMKn4ZLbYf",
                     "route": {
@@ -14583,7 +15075,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "ChIJfRqPmoCjhVQRxKn9ci4Yd44"
                     },
-                    "notes": "House is on the corner of Orleans and E Illinois. Deliver to the side door by the garage at the end of the driveway (on E Illinois).",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -14593,7 +15085,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/Ye94X1pXOYuMKn4ZLbYf",
                     "route": {
@@ -14612,7 +15105,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "EisyNzA5IE1vb3JlIFN0ICMxLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh0aGwoWChQKEgmHYWpFgaOFVBFu8iBVebsT-RIBMQ"
                     },
-                    "notes": "Google Maps will try to take you to Moore St via E North St, DISREGARD THESE DIRECTIONS. Instead, access Moore St from E Maryland St. Deliver to apartment door and knock.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -14622,7 +15115,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/Ye94X1pXOYuMKn4ZLbYf",
                     "route": {
@@ -14641,7 +15135,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "Ei0xNTQ4IEUgTWFyeWxhbmQgU3QsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiMRIvChQKEgllmYa7eKSFVBF11LeBEkSyFhCMDCoUChIJMWQ0vnikhVQR-Rq9gyaUtzg"
                     },
-                    "notes": "House is kind of tucked away. On the corner of Racine and E Maryland, there's a row of white mailboxes to the right of the recipient's driveway. Go up the driveway and look for the middle of three duplex buildings on your right. Address numbers are posted on the recipient's garage.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -14651,7 +15145,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/Ye94X1pXOYuMKn4ZLbYf",
                     "route": {
@@ -14670,7 +15165,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "EisyNzA1IE1vb3JlIFN0ICMzLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh0aGwoWChQKEgkpmyBPgaOFVBHz6PKNt7mBVxIBMw"
                     },
-                    "notes": "Google Maps will try to take you to Moore St via E North St, DISREGARD THESE DIRECTIONS. Instead, access Moore St from E Maryland St.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -14680,7 +15175,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/Ye94X1pXOYuMKn4ZLbYf",
                     "route": {
@@ -14706,7 +15202,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "EjMxMTAxIFdvb2RzdG9jayBXYXkgYiA0IGEsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiIRofChYKFAoSCUuq9v-BpIVUEZOYTO_oya5jEgViIDQgYQ"
                     },
-                    "notes": "Sunset Pond Apartments - Recipient's building can be hard to find. It's in the back row of buildings, closest to the pond behind. Their unit is basement level. Take the stairs that wrap around to the back of the building to access. They are in the first unit at the bottom of the stairs, with a tan shelf next to the door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -14716,7 +15212,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/ZAmAzTLxkcc2QYYQuIGw",
                     "route": {
@@ -14735,7 +15232,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "Ei4xNDAxIEUgU3Vuc2V0IERyICM0LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh0aGwoWChQKEglpdZHDgKSFVBFsY_d7KnHiEBIBNA"
                     },
-                    "notes": "Sunset Studios - Building numbers may be hidden by trees. ***Please let Sierra know if there is unused food outside door.***",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -14745,7 +15242,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/ZAmAzTLxkcc2QYYQuIGw",
                     "route": {
@@ -14764,7 +15262,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "EjMxMTA1IFdvb2RzdG9jayBXYXkgMjAzIGssIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiIRofChYKFAoSCb8NiQ6BpIVUEfWT3kVrnzYhEgUyMDMgaw"
                     },
-                    "notes": "Sunset Pond Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -14774,7 +15272,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/ZAmAzTLxkcc2QYYQuIGw",
                     "route": {
@@ -14793,7 +15292,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "Ei4xNDAxIEUgU3Vuc2V0IERyICM3LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh0aGwoWChQKEglpdZHDgKSFVBFsY_d7KnHiEBIBNw"
                     },
-                    "notes": "Sunset Studios",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -14803,7 +15302,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/ZAmAzTLxkcc2QYYQuIGw",
                     "route": {
@@ -14822,7 +15322,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "Ei8xNDAzIEUgU3Vuc2V0IERyICMxNCwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIeGhwKFgoUChIJN5W-xICkhVQRNObmfHAaxzYSAjE0"
                     },
-                    "notes": "Sunset Studios",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -14832,7 +15332,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/ZAmAzTLxkcc2QYYQuIGw",
                     "route": {
@@ -14851,7 +15352,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "ChIJkcM2EIGkhVQRt9sWLyiFXBs"
                     },
-                    "notes": "Sunset Pond Apartments - Recipient's unit is on the second floor, on the corner of their building.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -14861,7 +15362,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/ZAmAzTLxkcc2QYYQuIGw",
                     "route": {
@@ -14880,7 +15382,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "Ei4zMzUzIFJhY2luZSBTdCAjMjMzLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgkRTCYsh6SFVBEplppxrCSWYxIDMjMz"
                     },
-                    "notes": "Woodrose Apartments* - Last name Gunn",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 16,
                     "orderInfo": {
@@ -14890,7 +15392,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/ZAmAzTLxkcc2QYYQuIGw",
                     "route": {
@@ -14909,7 +15412,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "Ei4xNDAxIEUgU3Vuc2V0IERyICMyLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh0aGwoWChQKEglpdZHDgKSFVBFsY_d7KnHiEBIBMg"
                     },
-                    "notes": "Sunset Studios - Building numbers may be hidden by trees. Unit is on the ground floor.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -14919,7 +15422,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/ZAmAzTLxkcc2QYYQuIGw",
                     "route": {
@@ -14938,7 +15442,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "Ei8xNDA1IEUgU3Vuc2V0IERyICMxNywgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIeGhwKFgoUChIJh5jn2oCkhVQRLHUWreNEIsESAjE3"
                     },
-                    "notes": "Sunset Studios",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -14948,7 +15452,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/ZAmAzTLxkcc2QYYQuIGw",
                     "route": {
@@ -14967,7 +15472,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "Ei4zMzAzIFJhY2luZSBTdCAjMzIwLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgnF2Ooyh6SFVBEDd7ddl19GxhIDMzIw"
                     },
-                    "notes": "Woodrose Apartments* - Last name Lascona or Lascano",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -14977,7 +15482,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/ZAmAzTLxkcc2QYYQuIGw",
                     "route": {
@@ -15001,7 +15507,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "EjMxMTA3IFdvb2RzdG9jayBXYXkgMjAzIGwsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiIRofChYKFAoSCSHb2xCBpIVUEViqsNSY9Su6EgUyMDMgbA"
                     },
-                    "notes": "Sunset Pond Apartments - Recipient's front door is directly facing the back of the Safeway on Sunset. Must use the public sidewalk to access front door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -15011,7 +15517,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/ZAmAzTLxkcc2QYYQuIGw",
                     "route": {
@@ -15030,7 +15537,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "Ei4zMzUzIFJhY2luZSBTdCAjMjE0LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgkRTCYsh6SFVBEplppxrCSWYxIDMjE0"
                     },
-                    "notes": "Woodrose Apartments* - Last name Darling",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 17,
                     "orderInfo": {
@@ -15040,7 +15547,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/ZAmAzTLxkcc2QYYQuIGw",
                     "route": {
@@ -15059,7 +15567,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "Ei4zMzAzIFJhY2luZSBTdCAjMTM3LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgnF2Ooyh6SFVBEDd7ddl19GxhIDMTM3"
                     },
-                    "notes": "Woodrose Apartments* - Last name Wharton",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -15069,7 +15577,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/ZAmAzTLxkcc2QYYQuIGw",
                     "route": {
@@ -15088,7 +15597,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "Ei4zMzAzIFJhY2luZSBTdCAjMTAyLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgnF2Ooyh6SFVBEDd7ddl19GxhIDMTAy"
                     },
-                    "notes": "Woodrose Apartments* - Last name Reitler",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -15098,7 +15607,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/ZAmAzTLxkcc2QYYQuIGw",
                     "route": {
@@ -15117,7 +15627,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -15125,7 +15635,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/ZAmAzTLxkcc2QYYQuIGw",
                     "route": {
@@ -15144,7 +15655,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "Ei4zMzAzIFJhY2luZSBTdCAjMTE1LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgnF2Ooyh6SFVBEDd7ddl19GxhIDMTE1"
                     },
-                    "notes": "Woodrose Apartments* - Last name Wilson",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -15154,7 +15665,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/ZAmAzTLxkcc2QYYQuIGw",
                     "route": {
@@ -15173,7 +15685,7 @@
                         "addressLineTwo": "stop-1-6 addressLineTwo",
                         "placeId": "Ei8xNDA1IEUgU3Vuc2V0IERyICMxOSwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIeGhwKFgoUChIJh5jn2oCkhVQRLHUWreNEIsESAjE5"
                     },
-                    "notes": "Sunset Studios",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -15183,7 +15695,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/ZAmAzTLxkcc2QYYQuIGw",
                     "route": {
@@ -15202,7 +15715,7 @@
                         "addressLineTwo": "stop-1-7 addressLineTwo",
                         "placeId": "Ei8xNDAzIEUgU3Vuc2V0IERyICMxMCwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIeGhwKFgoUChIJN5W-xICkhVQRNObmfHAaxzYSAjEw"
                     },
-                    "notes": "Sunset Studios - Building numbers may be hidden by trees. We DO NOT have a current phone number for this recipient.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -15212,7 +15725,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/ZAmAzTLxkcc2QYYQuIGw",
                     "route": {
@@ -15238,7 +15752,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "Ei0yMDAwIEFsYWJhbWEgU3QgIzksIEJlbGxpbmdoYW0sIFdBIDk4MjI5LCBVU0EiHRobChYKFAoSCfl3Wu93pIVUEaYMh2LVC6QcEgE5"
                     },
-                    "notes": "Recipient's building is on the corner of Alabama and Verona, front door faces Alabama. Their unit is upstairs.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -15248,7 +15762,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/ZvXXdZc7HLlPIryMb4fP",
                     "route": {
@@ -15267,7 +15782,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "Ei0xOTIwIEFsYWJhbWEgU3QgIzMsIEJlbGxpbmdoYW0sIFdBIDk4MjI5LCBVU0EiHRobChYKFAoSCYEWJOV3pIVUERUyndTa36S9EgEz"
                     },
-                    "notes": "Please deliver to apartment door",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -15277,7 +15792,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/ZvXXdZc7HLlPIryMb4fP",
                     "route": {
@@ -15306,7 +15822,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/ZvXXdZc7HLlPIryMb4fP",
                     "route": {
@@ -15325,7 +15842,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "Ei0yMjQ3IFdvYnVybiBTdCAjMTIsIEJlbGxpbmdoYW0sIFdBIDk4MjI5LCBVU0EiHhocChYKFAoSCRWTvSB2pIVUERDOLfSzJeV0EgIxMg"
                     },
-                    "notes": "Secondary number is 206-578-5979.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -15335,7 +15852,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/ZvXXdZc7HLlPIryMb4fP",
                     "route": {
@@ -15354,7 +15872,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "ChIJcbqyMHakhVQRdP_bUqOHl2E"
                     },
-                    "notes": "WTA bus stop is directly in front of house.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -15364,7 +15882,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/ZvXXdZc7HLlPIryMb4fP",
                     "route": {
@@ -15383,7 +15902,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "Ei4yMTAwIEFsYWJhbWEgU3QgYTE2LCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEgmLlUK-d6SFVBFFJIZY0JxQcRIDYTE2"
                     },
-                    "notes": "Crimson Hills Townhomes -  A  section of complex runs parallel to Alabama St. The entrance is on the corner of Valencia and Alabama. Apt# is on post outside of each apartment.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -15393,7 +15912,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/ZvXXdZc7HLlPIryMb4fP",
                     "route": {
@@ -15412,7 +15932,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "Ei4yMDAwIEFsYWJhbWEgU3QgIzEwLCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh4aHAoWChQKEgn5d1rvd6SFVBGmDIdi1QukHBICMTA"
                     },
-                    "notes": "Recipient's unit is on the second floor.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -15422,7 +15942,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/ZvXXdZc7HLlPIryMb4fP",
                     "route": {
@@ -15441,7 +15962,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "Ei4yMTAwIEFsYWJhbWEgU3QgdDEyLCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEgmLlUK-d6SFVBFFJIZY0JxQcRIDdDEy"
                     },
-                    "notes": "Crimson Hills Townhomes -  T  section of complex runs parallel to Texas St. Apt# is on post outside of each apartment. PLEASE DO NOT KNOCK.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -15451,7 +15972,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/ZvXXdZc7HLlPIryMb4fP",
                     "route": {
@@ -15470,7 +15992,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "Ei4yMTAwIEFsYWJhbWEgU3QgdzEzLCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEgmLlUK-d6SFVBFFJIZY0JxQcRIDdzEz"
                     },
-                    "notes": "Crimson Hills Townhomes -  W  section of complex runs parallel to Woburn. If turning onto Woburn from Alabama, take the second driveway. Apt# is on post outside of each apartment.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -15480,7 +16002,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/ZvXXdZc7HLlPIryMb4fP",
                     "route": {
@@ -15509,7 +16032,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/ZvXXdZc7HLlPIryMb4fP",
                     "route": {
@@ -15533,7 +16057,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "Ei4yMzI4IFZhbGVuY2lhIFN0ICMzLCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh0aGwoWChQKEgmluh3Td6SFVBELpL2BooeY_xIBMw"
                     },
-                    "notes": "Complex is on the southeast corner of Texas and Valencia. Recipient's unit is in the building closest to the corner, upstairs. The staircase and handrail to apartment are rickety, USE CAUTION.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -15543,7 +16067,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/ZvXXdZc7HLlPIryMb4fP",
                     "route": {
@@ -15562,7 +16087,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -15570,7 +16095,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/ZvXXdZc7HLlPIryMb4fP",
                     "route": {
@@ -15589,7 +16115,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "ChIJeW305nekhVQRXdX8Oq5h1Ls"
                     },
-                    "notes": "Recipient lives in a duplex and the address is difficult to spot. Their unit is the one without the stairs, where a little dog will be barking. Sometimes there is a little white car or a big gold SUV outside.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -15599,7 +16125,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/ZvXXdZc7HLlPIryMb4fP",
                     "route": {
@@ -15625,7 +16152,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "EjIxNDMwIEJpcmNod29vZCBBdmUgIzEwNSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJFW_3226jhVQRwlsMLJOvDqcSAzEwNQ"
                     },
-                    "notes": "Brampton Court Apartments - Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -15635,7 +16162,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/cKfFSEF0S1GcoTUhMZVT",
                     "route": {
@@ -15654,7 +16182,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "EjIxNDIwIEJpcmNod29vZCBBdmUgIzIwNywgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJh0cu3m6jhVQRDywsxHfU3RoSAzIwNw"
                     },
-                    "notes": "Brampton Court Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -15664,7 +16192,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/cKfFSEF0S1GcoTUhMZVT",
                     "route": {
@@ -15683,7 +16212,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "EjIxNDQwIEJpcmNod29vZCBBdmUgIzEwMSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJObVB7G6jhVQRyiBi8qIsN2kSAzEwMQ"
                     },
-                    "notes": "Brampton Court Apartments - The 1440 building is all the way in the back. Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -15693,7 +16222,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/cKfFSEF0S1GcoTUhMZVT",
                     "route": {
@@ -15712,7 +16242,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "EjIxNDgwIEJpcmNod29vZCBBdmUgIzEwMiwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSI6GjgKMRIvChQKEgktOPOGbqOFVBGjq7qMfXh0dRDICyoUChIJpQ-UFGyjhVQRRZmgow1SrIoSAzEwMg"
                     },
-                    "notes": "Brampton Court Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -15722,7 +16252,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/cKfFSEF0S1GcoTUhMZVT",
                     "route": {
@@ -15741,7 +16272,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "ChIJD70e9UWjhVQRwvJYS-0m9lU"
                     },
-                    "notes": "Brampton Court Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -15751,7 +16282,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/cKfFSEF0S1GcoTUhMZVT",
                     "route": {
@@ -15770,7 +16302,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "ChIJP-17ItWjhVQRSYWujjno4Aw"
                     },
-                    "notes": "Woodway Senior Living - deliver to front desk and staff will deliver to recipient's room",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -15780,7 +16312,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/cKfFSEF0S1GcoTUhMZVT",
                     "route": {
@@ -15799,7 +16332,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "EjIxMzA4IEJpcmNod29vZCBBdmUgIzEwMywgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJg-XnGW-jhVQRbF02Gy6RuvISAzEwMw"
                     },
-                    "notes": "Birchwood Manor Apartments - Call 103 on call box.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -15809,7 +16342,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/cKfFSEF0S1GcoTUhMZVT",
                     "route": {
@@ -15828,7 +16362,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "EjIxNDgwIEJpcmNod29vZCBBdmUgIzEwOCwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSI6GjgKMRIvChQKEgktOPOGbqOFVBGjq7qMfXh0dRDICyoUChIJpQ-UFGyjhVQRRZmgow1SrIoSAzEwOA"
                     },
-                    "notes": "Brampton Court Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -15838,7 +16372,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/cKfFSEF0S1GcoTUhMZVT",
                     "route": {
@@ -15857,7 +16392,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "EjAzMDA1IE5vcnRod2VzdCBBdmUgIzgsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHRobChYKFAoSCfVBSPRyo4VUERp4Nmn6Qvl2EgE4"
                     },
-                    "notes": "Front door step",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -15867,7 +16402,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/cKfFSEF0S1GcoTUhMZVT",
                     "route": {
@@ -15886,7 +16422,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "EjIxNDIwIEJpcmNod29vZCBBdmUgIzIwNCwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJh0cu3m6jhVQRDywsxHfU3RoSAzIwNA"
                     },
-                    "notes": "Brampton Court Apartments - after entering the complex, turn right. Recipient is in the second to last building on the right, toward the back of the complex.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -15896,7 +16432,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/cKfFSEF0S1GcoTUhMZVT",
                     "route": {
@@ -15920,7 +16457,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -15928,7 +16465,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/cKfFSEF0S1GcoTUhMZVT",
                     "route": {
@@ -15947,7 +16485,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "EjIxNDgwIEJpcmNod29vZCBBdmUgIzMwNiwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSI6GjgKMRIvChQKEgktOPOGbqOFVBGjq7qMfXh0dRDICyoUChIJpQ-UFGyjhVQRRZmgow1SrIoSAzMwNg"
                     },
-                    "notes": "Brampton Court Apartments - Recipient's unit is on the top floor.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -15957,7 +16495,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/cKfFSEF0S1GcoTUhMZVT",
                     "route": {
@@ -15976,7 +16515,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "EjIxNDEwIEJpcmNod29vZCBBdmUgIzEwNCwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSI6GjgKMRIvChQKEgnlq-73bqOFVBHhNIoRbcrJfRCCCyoUChIJpQ-UFGyjhVQRRZmgow1SrIoSAzEwNA"
                     },
-                    "notes": "Brampton Court Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -15986,7 +16525,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/cKfFSEF0S1GcoTUhMZVT",
                     "route": {
@@ -16012,7 +16552,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "Eik4MTYgMjR0aCBTdCAjNSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIdGhsKFgoUChIJRb_xSCyihVQRYNBHNhXzq3sSATU"
                     },
-                    "notes": "Beech Apartments - On the corner of 24th and Taylor Ave. The building's parking lot is on the north end (closer to Taylor). Use the ramp to access apartments. Please ring doorbell. Do not be alarmed by loud dog barking inside.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -16022,7 +16562,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/cWGOAi5v9d1vPa0gfPqE",
                     "route": {
@@ -16041,7 +16582,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "Ei4yNjE0IERvdWdsYXMgQXZlICMzLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh0aGwoWChQKEglpQw6XK6KFVBFxChzGG8ptfxIBMw"
                     },
-                    "notes": "There are two recipients at this address - Mathew and Dezmond. Please deliver both boxes to apartment door and DO NOT KNOCK.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -16051,7 +16592,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/cWGOAi5v9d1vPa0gfPqE",
                     "route": {
@@ -16070,7 +16612,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -16078,7 +16620,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/cWGOAi5v9d1vPa0gfPqE",
                     "route": {
@@ -16097,7 +16640,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "Ei4yNjE0IERvdWdsYXMgQXZlICMzLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh0aGwoWChQKEglpQw6XK6KFVBFxChzGG8ptfxIBMw"
                     },
-                    "notes": "There are two recipients at this address - Mathew and Dezmond. Please deliver both boxes to apartment door and DO NOT KNOCK.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -16107,7 +16650,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/cWGOAi5v9d1vPa0gfPqE",
                     "route": {
@@ -16126,7 +16670,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "Eik4MTYgMjR0aCBTdCAjNywgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIdGhsKFgoUChIJRb_xSCyihVQRYNBHNhXzq3sSATc"
                     },
-                    "notes": "Beech Apartments - On the corner of 24th and Taylor Ave. The building's parking lot is on the north end (closer to Taylor). Use the ramp to access apartments.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -16136,7 +16680,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/cWGOAi5v9d1vPa0gfPqE",
                     "route": {
@@ -16155,7 +16700,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "EjcyMzAwIEJpbGwgTWNEb25hbGQgUGt3eSAjMTA1LCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgkn9LJMLKKFVBHHNMHM1S3Y2RIDMTA1"
                     },
-                    "notes": "Viking Gardens Apartments - Apartment building access is at the dead end of 24th St. Unit is in the building to the right at the dead end. There are two recipients at this address (Emilee and Juleyana), please deliver both boxes to the door and knock.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -16165,7 +16710,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/cWGOAi5v9d1vPa0gfPqE",
                     "route": {
@@ -16184,7 +16730,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "EiwxMDIwIDI0dGggU3QgIzIwMywgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJgdd-WimihVQR9AFl1lm_thwSAzIwMw"
                     },
-                    "notes": "Rhododendron Court Apartments - Building 1020 is the one on the left when you enter from 24th St. Recipient's unit is located on the farthest side of the building (closest to the dumpsters) and up the stairs.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -16194,7 +16740,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/cWGOAi5v9d1vPa0gfPqE",
                     "route": {
@@ -16213,7 +16760,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "EjAyMjExIERvdWdsYXMgQXZlICMzMDEsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHxodChYKFAoSCf3sD6QuooVUEVIKobuJhHz7EgMzMDE"
                     },
-                    "notes": "Alexandra Apartments - Take the road off Douglas that's just west of JJ's Food Mart. You'll see a parking garage area and then a road directly afterwards. Recipient suggests taking the road after the garage and parking there.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -16223,7 +16770,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/cWGOAi5v9d1vPa0gfPqE",
                     "route": {
@@ -16242,7 +16790,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "Ei4yMzAzIFRheWxvciBBdmUgIzE5LCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh4aHAoWChQKEgkpSRM2LKKFVBESP9olnNPVchICMTk"
                     },
-                    "notes": "Building and parking lot are accessed from Taylor Ave off of 24th St. Please ring doorbell when making delivery.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -16252,7 +16800,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/cWGOAi5v9d1vPa0gfPqE",
                     "route": {
@@ -16271,7 +16820,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "Eig5MzIgMjV0aCBTdCBhLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh0aGwoWChQKEgkXlFkJLKKFVBHp1Cx_hHxuAxIBYQ"
                     },
-                    "notes": "Look for the house on the corner of 25th and Douglas Ave. Access the carport from Douglas and deliver to the door underneath.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -16281,7 +16830,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/cWGOAi5v9d1vPa0gfPqE",
                     "route": {
@@ -16305,7 +16855,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "Eio4MTYgMjR0aCBTdCAjMTAsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHhocChYKFAoSCUW_8UgsooVUEWDQRzYV86t7EgIxMA"
                     },
-                    "notes": "Beech Apartments - On the corner of 24th and Taylor Ave. The building's parking lot is on the north end (closer to Taylor). Use the ramp to access apartments.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -16315,7 +16865,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/cWGOAi5v9d1vPa0gfPqE",
                     "route": {
@@ -16334,7 +16885,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "EioxMDIxIDI0dGggU3QgIzEsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHRobChYKFAoSCc2eyfwrooVUEY_DQrR6RIcVEgEx"
                     },
-                    "notes": "The Fremont - Deliver to porch.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -16344,7 +16895,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/cWGOAi5v9d1vPa0gfPqE",
                     "route": {
@@ -16363,7 +16915,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "Eik5MDkgMjJuZCBTdCAjOSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIdGhsKFgoUChIJfZwoKCyihVQRGlNz_XW2bV8SATk"
                     },
-                    "notes": "Recipient's unit is in the building on the left at the end of parking lot, on the second floor. Apartment door faces the dumpster. Please deliver to the top of the stairs.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -16373,7 +16925,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/cWGOAi5v9d1vPa0gfPqE",
                     "route": {
@@ -16392,7 +16945,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "EiwxMDI1IDIzcmQgU3QgIzIwMywgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJo_KxTymihVQRDcsjgt0BbF4SAzIwMw"
                     },
-                    "notes": "Apartment is located in back of the building. Alternative phone number is 206-561-3889.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -16402,7 +16955,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/cWGOAi5v9d1vPa0gfPqE",
                     "route": {
@@ -16421,7 +16975,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "EjcyMzAwIEJpbGwgTWNEb25hbGQgUGt3eSAjMTA1LCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgkn9LJMLKKFVBHHNMHM1S3Y2RIDMTA1"
                     },
-                    "notes": "Viking Gardens Apartments - Apartment building access is at the dead end of 24th St. Unit is in the building to the right at the dead end. There are two recipients at this address (Emilee and Juleyana), please deliver both boxes to the door and knock.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -16431,7 +16985,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/cWGOAi5v9d1vPa0gfPqE",
                     "route": {
@@ -16450,7 +17005,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "EiwxMDExIDIzcmQgU3QgIzEwMSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJQ1ezrC6ihVQR2rxXWxPTqQYSAzEwMQ"
                     },
-                    "notes": "Recipient's door is on the side of the apartment complex behind the stairs.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -16460,7 +17015,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/cWGOAi5v9d1vPa0gfPqE",
                     "route": {
@@ -16486,7 +17042,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "EiwyNDU4IE1jS2VuemllIEF2ZSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIxEi8KFAoSCW-7Z-IpooVUEYhpBW_KVObcEJoTKhQKEglzc6DlI6KFVBGiYrFuOdSnng"
                     },
-                    "notes": "Varsity Village* - Unit is past the second playground at the end, look for a peacock windchime out front.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -16496,7 +17052,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/dVK6mGKdc2jwTDhpSE8C",
                     "route": {
@@ -16515,7 +17072,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "Ei0xMDExIExlbm9yYSBDdCAjOTksIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHhocChYKFAoSCfsOCsYuooVUET6WJSJ-7roVEgI5OQ"
                     },
-                    "notes": "Samish Heights - Recipient is on the ground floor, her unit is on the right when facing the building.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -16525,7 +17082,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/dVK6mGKdc2jwTDhpSE8C",
                     "route": {
@@ -16544,7 +17102,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "EjUyMTEwIEJpbGwgTWNEb25hbGQgUGt3eSAjMywgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIdGhsKFgoUChIJbQM6di6ihVQRJqoCVGbMHoQSATM"
                     },
-                    "notes": "University Heights - Access to this complex is at the end of 22nd St. From there, take a left and go to the end of the road then turn right into the parking lot. Unit #3 is above the leasing office accessed via stairs on the left side of the building from the parking lot.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -16554,7 +17112,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/dVK6mGKdc2jwTDhpSE8C",
                     "route": {
@@ -16573,7 +17132,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -16581,7 +17140,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/dVK6mGKdc2jwTDhpSE8C",
                     "route": {
@@ -16600,7 +17160,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "EiwyNDM2IE1jS2VuemllIEF2ZSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIxEi8KFAoSCZELYcUpooVUEY-v6DJwM91rEIQTKhQKEglzc6DlI6KFVBGiYrFuOdSnng"
                     },
-                    "notes": "Varsity Village*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -16610,7 +17170,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/dVK6mGKdc2jwTDhpSE8C",
                     "route": {
@@ -16629,7 +17190,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "ChIJi9MlzSmihVQRkSC0MHs566M"
                     },
-                    "notes": "Varsity Village*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -16639,7 +17200,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/dVK6mGKdc2jwTDhpSE8C",
                     "route": {
@@ -16658,7 +17220,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "EiwyNDcyIE1jS2VuemllIEF2ZSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIxEi8KFAoSCW-7Z-IpooVUEYhpBW_KVObcEKgTKhQKEglzc6DlI6KFVBGiYrFuOdSnng"
                     },
-                    "notes": "Varsity Village*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -16668,7 +17230,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/dVK6mGKdc2jwTDhpSE8C",
                     "route": {
@@ -16687,7 +17250,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "ChIJyZ0Obi6ihVQRYejld9zkUKo"
                     },
-                    "notes": "University Hills Apartments - Go to the end of the roas, parking lot is on the left. Recipient's unit is on the left halfway down.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -16697,7 +17260,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/dVK6mGKdc2jwTDhpSE8C",
                     "route": {
@@ -16716,7 +17280,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "ChIJJS5K3ymihVQRBnzrPBOb8_k"
                     },
-                    "notes": "Varsity Village*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -16726,7 +17290,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/dVK6mGKdc2jwTDhpSE8C",
                     "route": {
@@ -16745,7 +17310,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "ChIJowvy1SmihVQRRQwK8AyRl2g"
                     },
-                    "notes": "Varsity Village*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -16755,7 +17320,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/dVK6mGKdc2jwTDhpSE8C",
                     "route": {
@@ -16779,7 +17345,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "Ei4xMDA5IExlbm9yYSBDdCAjMjAyLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEglRHqnILqKFVBEmveWah7W6PhIDMjAy"
                     },
-                    "notes": "Samish Heights Apartments - Apartment is located in the back of Building B.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -16789,7 +17355,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/dVK6mGKdc2jwTDhpSE8C",
                     "route": {
@@ -16808,7 +17375,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "ChIJzTIC1ymihVQR9pn4QgNXpUg"
                     },
-                    "notes": "Varsity Village*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -16818,7 +17385,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/dVK6mGKdc2jwTDhpSE8C",
                     "route": {
@@ -16837,7 +17405,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "ChIJ-wGp3ymihVQR7ytyhKAkuMY"
                     },
-                    "notes": "Varsity Village* - KNOCK QUIETLY, recipient has PTSD.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -16847,7 +17415,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/dVK6mGKdc2jwTDhpSE8C",
                     "route": {
@@ -16866,7 +17435,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "EiwyNDgyIE1jS2VuemllIEF2ZSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIxEi8KFAoSCW-7Z-IpooVUEYhpBW_KVObcELITKhQKEglzc6DlI6KFVBGiYrFuOdSnng"
                     },
-                    "notes": "Varsity Village* - Place the box at the door, not at bottom of ramp.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -16876,7 +17445,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/dVK6mGKdc2jwTDhpSE8C",
                     "route": {
@@ -16895,7 +17465,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "Ei4xMDExIExlbm9yYSBDdCAjMTExLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgn7DgrGLqKFVBE-liUifu66FRIDMTEx"
                     },
-                    "notes": "Samish Heights",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -16905,7 +17475,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/dVK6mGKdc2jwTDhpSE8C",
                     "route": {
@@ -16924,7 +17495,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "EiwyNDY2IE1jS2VuemllIEF2ZSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIxEi8KFAoSCW-7Z-IpooVUEYhpBW_KVObcEKITKhQKEglzc6DlI6KFVBGiYrFuOdSnng"
                     },
-                    "notes": "Varsity Village*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -16934,7 +17505,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/dVK6mGKdc2jwTDhpSE8C",
                     "route": {
@@ -16960,7 +17532,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "ChIJ6zH3TaWxhVQRyie9nuOg6qs"
                     },
-                    "notes": "Recipients are in the 5th house on the outside of the circle right as you pull in.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -16970,7 +17542,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -16989,7 +17562,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "EiIyMDUgQmFrZXIgU3RyZWV0LCBFdmVyc29uLCBXQSwgVVNBIjESLwoUChIJG_lq11-xhVQRCaijRd751DAQzQEqFAoSCbcPDXVgsYVUEY0CUiEhQx4h"
                     },
-                    "notes": "Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 35,
                     "orderInfo": {
@@ -16999,7 +17572,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17028,7 +17602,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17047,7 +17622,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "ChIJb3v4SROxhVQRf7QJ0qHVoyU"
                     },
-                    "notes": "Deliver to front door",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 22,
                     "orderInfo": {
@@ -17057,7 +17632,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17076,7 +17652,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "Eio2NDU1IE1pc3Npb24gUmQgIzMsIEV2ZXJzb24sIFdBIDk4MjQ3LCBVU0EiHRobChYKFAoSCQ3fZNi0sYVUEYHWkLJjgEVgEgEz"
                     },
-                    "notes": "Mission Road Apartments - Driveway is south of and next to Goshen Community Church. There are TWO RECIPIENTS AT THIS ADDRESS (Diana and Brenda). Please deliver both boxes to their door. Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -17086,7 +17662,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17105,7 +17682,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "ChIJBwTvGi2uhVQR6EueDleDujI"
                     },
-                    "notes": "House is at the end of a dead end road. There are many potholes on the road to the house, DRIVE SLOW.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -17115,7 +17692,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17134,7 +17712,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "Eig1OTE5IEZhem9uIFJkLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIjESLwoUChIJZbaIKiqwhVQRQjSkcN2WKmIQny4qFAoSCZ0fNb4usIVUEdbdjjJHOAcg"
                     },
-                    "notes": "Recipients share a drive way with neighbors. Please look for the blue/grey house (NOT the yellow house).",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -17144,7 +17722,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17163,7 +17742,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "ChIJJxLp-fyxhVQRMPxjTrWFR0E"
                     },
-                    "notes": "Please leave box on the wooden bench on the north side of the house. You'll drive past the little desk in between the shop and the house and will see the bench against the house on the right hand side. Park in front of the small detached garage. Please place protein in the white styrofoam cooler during the summer months.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 42,
                     "orderInfo": {
@@ -17173,7 +17752,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17192,7 +17772,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "ChIJY6zry36mhVQRii9pHv6TRKc"
                     },
-                    "notes": "Agate Bay Mobile Estates - Drive up the paved road on the left just before the Y on N Shore Rd (where The Fork restaurant is). Please deliver to the ramp on the left, with the covered patio.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 45,
                     "orderInfo": {
@@ -17202,7 +17782,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17229,7 +17810,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17253,7 +17835,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "ChIJf8n13kiuhVQRG4h5M57rZrI"
                     },
-                    "notes": "Mt Baker Mobile Home Park - Please drive slow through the park. Recipient lives in a blue trailer with a covered porch and a baby gate. Please leave box on stairs or freezer.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 43,
                     "orderInfo": {
@@ -17263,7 +17845,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17282,7 +17865,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "Eik0MDcgVyAxc3QgU3QgIzQwNywgRXZlcnNvbiwgV0EgOTgyNDcsIFVTQSIfGh0KFgoUChIJw8rkzl2xhVQRBepLiPTJ35ASAzQwNw"
                     },
-                    "notes": "Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 36,
                     "orderInfo": {
@@ -17292,7 +17875,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17311,7 +17895,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "ChIJpY6bRmexhVQRxAhCBTBoH2o"
                     },
-                    "notes": "Address is at the end of a cul-de-sac. Recipients are Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 31,
                     "orderInfo": {
@@ -17321,7 +17905,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17350,7 +17935,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17369,7 +17955,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "Eio2NDU1IE1pc3Npb24gUmQgIzEsIEV2ZXJzb24sIFdBIDk4MjQ3LCBVU0EiHRobChYKFAoSCQ3fZNi0sYVUEYHWkLJjgEVgEgEx"
                     },
-                    "notes": "Mission Road Apartments - Driveway is south of and next to Goshen Community Church. Recipient is Mixteco-speaking with limited Spanish.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -17379,7 +17965,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17398,7 +17985,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "ChIJ1fXA1GaxhVQRzyNJVaoNUsI"
                     },
-                    "notes": "Yellow house. Walk toward the garage, take a left and you'll see the back door. Please deliver the box just inside the back door, recipient cannot bring the box in on her own.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 34,
                     "orderInfo": {
@@ -17408,7 +17995,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17427,7 +18015,7 @@
                         "addressLineTwo": "stop-1-6 addressLineTwo",
                         "placeId": "Eio3MDMgU3RyYW5kZWxsIFN0IGEsIEV2ZXJzb24sIFdBIDk4MjQ3LCBVU0EiHRobChYKFAoSCTOj341rsYVUEZ6FVqSlbwgXEgFh"
                     },
-                    "notes": "Two families receiving deliveries live in this unit. Please deliver both boxes to front door. Recipients are Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 26,
                     "orderInfo": {
@@ -17437,7 +18025,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17456,7 +18045,7 @@
                         "addressLineTwo": "stop-1-7 addressLineTwo",
                         "placeId": "ChIJb4skuj60hVQRUB5Y_zat-54"
                     },
-                    "notes": "Look for a yellow house with large windows visible from the road. Recipient lives in a room inside and has requested a call when the delivery is made. They are Spanish-speaking. If you do not speak Spanish, please call anyway and say,  La caja de comida esta aqui  this means  the food box is here.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 38,
                     "orderInfo": {
@@ -17466,7 +18055,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17495,7 +18085,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17524,7 +18115,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17548,7 +18140,7 @@
                         "addressLineTwo": "stop-2-0 addressLineTwo",
                         "placeId": "ChIJNybKAGelhVQRE6t2vHTPxvw"
                     },
-                    "notes": "Deliver to side porch by black car.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -17558,7 +18150,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17577,7 +18170,7 @@
                         "addressLineTwo": "stop-2-1 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -17585,7 +18178,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17604,7 +18198,7 @@
                         "addressLineTwo": "stop-2-2 addressLineTwo",
                         "placeId": "ChIJ917AFmGxhVQRdFXAfwE2bFc"
                     },
-                    "notes": "Everson Mobile Home Estates - Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 32,
                     "orderInfo": {
@@ -17614,7 +18208,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17633,7 +18228,7 @@
                         "addressLineTwo": "stop-2-3 addressLineTwo",
                         "placeId": "ChIJMyRX-H2lhVQRNEusFjYzFZA"
                     },
-                    "notes": "Address numbers can be difficult to see. Look for the first structure on the property - a faded brown garage with a white garage door - and deliver the box under the carport.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 44,
                     "orderInfo": {
@@ -17643,7 +18238,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17662,7 +18258,7 @@
                         "addressLineTwo": "stop-2-4 addressLineTwo",
                         "placeId": "ChIJP9RzaF2lhVQR2MVltBTMlk0"
                     },
-                    "notes": "Park just off of Kelly Rd (next to mailbox marked 1940) and walk along the path back to the trailer. There is a ramp leading up to the front door. Please leave box on the porch.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -17672,7 +18268,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17701,7 +18298,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17720,7 +18318,7 @@
                         "addressLineTwo": "stop-2-6 addressLineTwo",
                         "placeId": "ChIJT2JVHyqwhVQRM4A-ij53ok4"
                     },
-                    "notes": "Look for the first light blue house on the property.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -17730,7 +18328,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17759,7 +18358,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17778,7 +18378,7 @@
                         "addressLineTwo": "stop-2-8 addressLineTwo",
                         "placeId": "Eio2NDU1IE1pc3Npb24gUmQgIzMsIEV2ZXJzb24sIFdBIDk4MjQ3LCBVU0EiHRobChYKFAoSCQ3fZNi0sYVUEYHWkLJjgEVgEgEz"
                     },
-                    "notes": "Mission Road Apartments - Driveway is south of and next to Goshen Community Church. There are TWO RECIPIENTS AT THIS ADDRESS (Diana and Brenda). Please deliver both boxes to their door. Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -17788,7 +18388,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17807,7 +18408,7 @@
                         "addressLineTwo": "stop-2-9 addressLineTwo",
                         "placeId": "ChIJcRACnWyxhVQR4NDGKNMyr4w"
                     },
-                    "notes": "No delivery notes were provided. Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 23,
                     "orderInfo": {
@@ -17817,7 +18418,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17841,7 +18443,7 @@
                         "addressLineTwo": "stop-3-0 addressLineTwo",
                         "placeId": "ChIJizFGWxKxhVQRQcdR-zj2pDY"
                     },
-                    "notes": "Recipient lives in a 35ft RV called the Thor Regency that's parked next to the driveway.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 19,
                     "orderInfo": {
@@ -17851,7 +18453,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17870,7 +18473,7 @@
                         "addressLineTwo": "stop-3-1 addressLineTwo",
                         "placeId": "Eio3MDEgU3RyYW5kZWxsIFN0IGQsIEV2ZXJzb24sIFdBIDk4MjQ3LCBVU0EiHRobChYKFAoSCd0y-5JrsYVUEeq0ALK6VL1vEgFk"
                     },
-                    "notes": "Recipient is Spanish-speaking. Their unit is on the second floor.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 28,
                     "orderInfo": {
@@ -17880,7 +18483,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17899,7 +18503,7 @@
                         "addressLineTwo": "stop-3-2 addressLineTwo",
                         "placeId": "ChIJJ4CVaPuwhVQROHnVzPI_IiM"
                     },
-                    "notes": "There are two recipients at this address (Arthur & Lilliana). Please deliver both boxes to the dark brown house next to a green shed.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 16,
                     "orderInfo": {
@@ -17909,7 +18513,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17938,7 +18543,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17957,7 +18563,7 @@
                         "addressLineTwo": "stop-3-4 addressLineTwo",
                         "placeId": "ChIJw4cKPAClhVQRGWTbIjVRoYU"
                     },
-                    "notes": "Deliver to the deck, outside of the sliding glass door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -17967,7 +18573,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -17986,7 +18593,7 @@
                         "addressLineTwo": "stop-3-5 addressLineTwo",
                         "placeId": "ChIJ917AFmGxhVQRdFXAfwE2bFc"
                     },
-                    "notes": "Everson Mobile Home Estates - Recipients are Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 33,
                     "orderInfo": {
@@ -17996,7 +18603,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -18015,7 +18623,7 @@
                         "addressLineTwo": "stop-3-6 addressLineTwo",
                         "placeId": "ChIJJ4CVaPuwhVQROHnVzPI_IiM"
                     },
-                    "notes": "There are two recipients at this address (Arthur & Lilliana). Please deliver both boxes to the dark brown house next to a green shed.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 17,
                     "orderInfo": {
@@ -18025,7 +18633,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -18044,7 +18653,7 @@
                         "addressLineTwo": "stop-3-7 addressLineTwo",
                         "placeId": "EiYyNTU2IEdlb3JnZSBDdCwgRXZlcnNvbiwgV0EgOTgyNDcsIFVTQSIxEi8KFAoSCU8bI84KsYVUEZ4AWZ8mc2jlEPwTKhQKEglPGyPOCrGFVBFwq0k7s78Zkw"
                     },
-                    "notes": "front porch",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -18054,7 +18663,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -18073,7 +18683,7 @@
                         "addressLineTwo": "stop-3-8 addressLineTwo",
                         "placeId": "Eik2MTAgUm9lZGVyIEF2ZSAjNCwgRXZlcnNvbiwgV0EgOTgyNDcsIFVTQSIdGhsKFgoUChIJS7sGYWmxhVQRHSnOC-kzguoSATQ"
                     },
-                    "notes": "Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 30,
                     "orderInfo": {
@@ -18083,7 +18693,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -18102,7 +18713,7 @@
                         "addressLineTwo": "stop-3-9 addressLineTwo",
                         "placeId": "Eio3MDMgU3RyYW5kZWxsIFN0IGEsIEV2ZXJzb24sIFdBIDk4MjQ3LCBVU0EiHRobChYKFAoSCTOj341rsYVUEZ6FVqSlbwgXEgFh"
                     },
-                    "notes": "Two families receiving deliveries live in this unit. Please deliver both boxes to front door. Recipients are Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 27,
                     "orderInfo": {
@@ -18112,7 +18723,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -18146,7 +18758,8 @@
                     },
                     "recipient": {
                         "name": "stop-4-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -18165,7 +18778,7 @@
                         "addressLineTwo": "stop-4-1 addressLineTwo",
                         "placeId": "ChIJmRH7uXalhVQRlGQFRThCNm0"
                     },
-                    "notes": "Blue house close to road, not hard to find.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -18175,7 +18788,8 @@
                     },
                     "recipient": {
                         "name": "stop-4-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -18194,7 +18808,7 @@
                         "addressLineTwo": "stop-4-2 addressLineTwo",
                         "placeId": "ChIJMUolNhuxhVQRRn3E0qI1Qd4"
                     },
-                    "notes": "There is a long driveway up to the house. Please deliver to the front steps.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 18,
                     "orderInfo": {
@@ -18204,7 +18818,8 @@
                     },
                     "recipient": {
                         "name": "stop-4-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -18223,7 +18838,7 @@
                         "addressLineTwo": "stop-4-3 addressLineTwo",
                         "placeId": "ChIJcaYV2xG0hVQRyt25V9pV6Xc"
                     },
-                    "notes": "Agressive German Sherphard lives on the property. Please text dog owner, Maria (360-961-3001), before arrival to be sure the dog is contained. Be aware of your surroundings before getting out of your vehicle and do not complete the delivery if you don't feel safe doing so. Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 37,
                     "orderInfo": {
@@ -18233,7 +18848,8 @@
                     },
                     "recipient": {
                         "name": "stop-4-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -18252,7 +18868,7 @@
                         "addressLineTwo": "stop-4-4 addressLineTwo",
                         "placeId": "ChIJDWDJEvuwhVQRbnlKZiYgzBg"
                     },
-                    "notes": "House fronts Pole Rd. Address number is on the beige house but may not be visible through the tree in the front yard. Deliver to front porch. Pull through driveway.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -18262,7 +18878,8 @@
                     },
                     "recipient": {
                         "name": "stop-4-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -18281,7 +18898,7 @@
                         "addressLineTwo": "stop-4-5 addressLineTwo",
                         "placeId": "Eic4MDcgRnJlZGEgQXZlIGEsIEV2ZXJzb24sIFdBIDk4MjQ3LCBVU0EiHRobChYKFAoSCSGQN4ZrsYVUEaBGowf_Ve-iEgFh"
                     },
-                    "notes": "Recipient is Spanish speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 25,
                     "orderInfo": {
@@ -18291,7 +18908,8 @@
                     },
                     "recipient": {
                         "name": "stop-4-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -18310,7 +18928,7 @@
                         "addressLineTwo": "stop-4-6 addressLineTwo",
                         "placeId": "ChIJE_C9To2zhVQRNj0rPbUCH7Y"
                     },
-                    "notes": "Recipient is Spanish-speaking. ***No delivery notes were provided, please tell Sierra if there is something to add here.***",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 40,
                     "orderInfo": {
@@ -18320,7 +18938,8 @@
                     },
                     "recipient": {
                         "name": "stop-4-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/dre5eVA30O7xe6zt3qgo",
                     "route": {
@@ -18346,7 +18965,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "EikxNjA4IEUgU3QgIzEwMSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJ21ctTKKjhVQR_v4Cvq8qFYoSAzEwMQ"
                     },
-                    "notes": "Courtyard Studios - Secured building with a broken call box. Please call recipient when you arrive and she will open the gate.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -18356,7 +18975,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/gT5HD9y2BmXAETQTEa9j",
                     "route": {
@@ -18375,7 +18995,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "EjExMTAgRSBDaGVzdG51dCBTdCAjMzAyLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgkHGNHku6OFVBHNeCb_DYXLGBIDMzAy"
                     },
-                    "notes": "Kateri Court* - Please call upon arrival. Recipient may want her box to be delivered to a chair outside her door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -18385,7 +19005,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/gT5HD9y2BmXAETQTEa9j",
                     "route": {
@@ -18404,7 +19025,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -18412,7 +19033,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/gT5HD9y2BmXAETQTEa9j",
                     "route": {
@@ -18431,7 +19053,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "EikxNTA1IEcgU3QgIzIwNiwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJ2aRPfKGjhVQRulBWFBwHph0SAzIwNg"
                     },
-                    "notes": "Harborview Apartments - Leave on table.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -18441,7 +19063,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/gT5HD9y2BmXAETQTEa9j",
                     "route": {
@@ -18460,7 +19083,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "EjExMTAgRSBDaGVzdG51dCBTdCAjNTA0LCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgkHGNHku6OFVBHNeCb_DYXLGBIDNTA0"
                     },
-                    "notes": "Kateri Court* - Phone number provided is for David's caregiver, Renee.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -18470,7 +19093,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/gT5HD9y2BmXAETQTEa9j",
                     "route": {
@@ -18489,7 +19113,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "EikxNTA1IEcgU3QgIzEwOSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJ2aRPfKGjhVQRulBWFBwHph0SAzEwOQ"
                     },
-                    "notes": "Harborview Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -18499,7 +19123,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/gT5HD9y2BmXAETQTEa9j",
                     "route": {
@@ -18525,7 +19150,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "ChIJpcnAbiOWhVQRpJg7ugN7nMM"
                     },
-                    "notes": "There are two recipients (Fawn and Ariannah) on this property. Deliver both boxes to the covered front porch of the main house.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 16,
                     "orderInfo": {
@@ -18535,7 +19160,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/heB8BGrXckMOKJixvFJh",
                     "route": {
@@ -18554,7 +19180,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "ChIJo3TzVGO8hVQRSzPZNMNRyW0"
                     },
-                    "notes": "Expect to hear loud barking when you drop the box, but know the dog cannot get out of the house. Please place box on top of wooden box on front porch.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -18564,7 +19190,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/heB8BGrXckMOKJixvFJh",
                     "route": {
@@ -18583,7 +19210,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "ChIJd-EUnDyWhVQR_4BNlhIfbCA"
                     },
-                    "notes": "Deliver to the small blue building to the right of the main house.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -18593,7 +19220,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/heB8BGrXckMOKJixvFJh",
                     "route": {
@@ -18612,7 +19240,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "Ei81MTE2IExhIEJvdW50eSBEciAjMTAxLCBGZXJuZGFsZSwgV0EgOTgyNDgsIFVTQSIfGh0KFgoUChIJZ3UhIxm9hVQR6mHVp9CpdqASAzEwMQ"
                     },
-                    "notes": "Willy Flats Apartments - Recipient is NOT in the first building you'll see at the entrance, head toward the back of the complex beyond the playground to find their building.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -18622,7 +19250,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/heB8BGrXckMOKJixvFJh",
                     "route": {
@@ -18641,7 +19270,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "ChIJy-vUAtOZhVQRlotXF6YQtVA"
                     },
-                    "notes": "Long driveway. Recipient's house is the first one on the left all the way at the end.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 20,
                     "orderInfo": {
@@ -18651,7 +19280,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/heB8BGrXckMOKJixvFJh",
                     "route": {
@@ -18670,7 +19300,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "ChIJrdCQeMWZhVQRCtuh6qtf16E"
                     },
-                    "notes": "Recipient lives at the dead end of Emma Rd. Please deliver to their front steps.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 22,
                     "orderInfo": {
@@ -18680,7 +19310,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/heB8BGrXckMOKJixvFJh",
                     "route": {
@@ -18699,7 +19330,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "ChIJo5wwR2K8hVQR9wgi9U-VzWo"
                     },
-                    "notes": "Recipient lives in a unit on the Ferndale Self Storage property. You will be able to see her door when you pull in. Look for the door without the ramp up to it. The address numbers are posted on the door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -18709,7 +19340,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/heB8BGrXckMOKJixvFJh",
                     "route": {
@@ -18738,7 +19370,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/heB8BGrXckMOKJixvFJh",
                     "route": {
@@ -18757,7 +19390,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "Ei81MTIyIExhIEJvdW50eSBEciAjMjEwLCBGZXJuZGFsZSwgV0EgOTgyNDgsIFVTQSIfGh0KFgoUChIJ3VKMIoq8hVQRz54Ryi-7WFgSAzIxMA"
                     },
-                    "notes": "Recipient's phone is not accepting calls at this time, please text if you need to reach him.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -18767,7 +19400,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/heB8BGrXckMOKJixvFJh",
                     "route": {
@@ -18786,7 +19420,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "Ei81Mzk2IE5vcnRod2VzdCBEciAjMiwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIdGhsKFgoUChIJHQlMRoC7hVQRsHkERElpCKISATI"
                     },
-                    "notes": "Recipient lives in the duplexes down a gravel road off of Northwest Dr. The road is on the east side of Northwest, between the fire station and Kent's Garden & Nursery. There are mail boxes on either side if the road. You will see duplexes on the right hand side after turning down the gravel road. Recipient is in the last one.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -18796,7 +19430,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/heB8BGrXckMOKJixvFJh",
                     "route": {
@@ -18820,7 +19455,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "Ei81MTMxIExhIEJvdW50eSBEciAjMTA2LCBGZXJuZGFsZSwgV0EgOTgyNDgsIFVTQSIfGh0KFgoUChIJX_in2WG8hVQRA0OC5epCuVYSAzEwNg"
                     },
-                    "notes": "Alder Creek Apartments - Recipient's unit is in Building A",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -18830,7 +19465,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/heB8BGrXckMOKJixvFJh",
                     "route": {
@@ -18849,7 +19485,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "ChIJ_83NnMWZhVQRQ4YqmSd8OrE"
                     },
-                    "notes": "Google Maps will direct you to the wrong house. Look for the property with a green VW van out front.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 21,
                     "orderInfo": {
@@ -18859,7 +19495,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/heB8BGrXckMOKJixvFJh",
                     "route": {
@@ -18878,7 +19515,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "Eig1NjAxIDNyZCBBdmUgIzMsIEZlcm5kYWxlLCBXQSA5ODI0OCwgVVNBIh0aGwoWChQKEglzvuYePryFVBGkUpXtsiQEoxIBMw"
                     },
-                    "notes": "Westwind Gardens - Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -18888,7 +19525,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/heB8BGrXckMOKJixvFJh",
                     "route": {
@@ -18907,7 +19545,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "ChIJpyytNhuYhVQRqeuBOYemI8o"
                     },
-                    "notes": "The address numbers on the mailbox are slightly damaged. Look for an open black gate at the entrance to the property. Walk up the ramp to deliver to the trailer door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 19,
                     "orderInfo": {
@@ -18917,7 +19555,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/heB8BGrXckMOKJixvFJh",
                     "route": {
@@ -18936,7 +19575,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "ChIJ-9Kbp1e8hVQRAXwhTH88DMg"
                     },
-                    "notes": "Follow gravel driveway to the end and go straight through the 3-way split. Recipient's trailer is directly behind the cream-colored house, backed up to the front of a shed. Please deliver to the shed or the other covered area behind the trailer.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -18946,7 +19585,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/heB8BGrXckMOKJixvFJh",
                     "route": {
@@ -18965,7 +19605,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -18973,7 +19613,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/heB8BGrXckMOKJixvFJh",
                     "route": {
@@ -18992,7 +19633,7 @@
                         "addressLineTwo": "stop-1-6 addressLineTwo",
                         "placeId": "ChIJLeZ28z27hVQRjCMsP6TYrHA"
                     },
-                    "notes": "Turn down the driveway along the white picket fence, just south of Martin's Automotive. The house (grey color with a brick bottom) is the first one on the left. Place food boxes on back deck.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -19002,7 +19643,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/heB8BGrXckMOKJixvFJh",
                     "route": {
@@ -19031,7 +19673,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/heB8BGrXckMOKJixvFJh",
                     "route": {
@@ -19050,7 +19693,7 @@
                         "addressLineTwo": "stop-1-8 addressLineTwo",
                         "placeId": "ChIJfYrpUV67hVQRVp5VNmUURIU"
                     },
-                    "notes": "Access trailer park from a small driveway immediately south of the fire station. Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -19060,7 +19703,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/heB8BGrXckMOKJixvFJh",
                     "route": {
@@ -19079,7 +19723,7 @@
                         "addressLineTwo": "stop-1-9 addressLineTwo",
                         "placeId": "ChIJb7ce_WK7hVQRAa-MCg2r41s"
                     },
-                    "notes": "House is salmon colored.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -19089,7 +19733,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/heB8BGrXckMOKJixvFJh",
                     "route": {
@@ -19113,7 +19758,7 @@
                         "addressLineTwo": "stop-2-0 addressLineTwo",
                         "placeId": "ChIJpcnAbiOWhVQRpJg7ugN7nMM"
                     },
-                    "notes": "There are two recipients (Fawn and Ariannah) on this property. Deliver both boxes to the covered front porch of the main house.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 17,
                     "orderInfo": {
@@ -19123,7 +19768,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/heB8BGrXckMOKJixvFJh",
                     "route": {
@@ -19142,7 +19788,7 @@
                         "addressLineTwo": "stop-2-1 addressLineTwo",
                         "placeId": "ChIJC4DyVEK9hVQRBnM8OiXVctA"
                     },
-                    "notes": "Recipient lives in one of two RVs on the property. His is the white fifth wheel with an orange stripe and tarps. It's set up on a hill. Please deliver to this trailer's door, not main house.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 18,
                     "orderInfo": {
@@ -19152,7 +19798,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/heB8BGrXckMOKJixvFJh",
                     "route": {
@@ -19171,7 +19818,7 @@
                         "addressLineTwo": "stop-2-2 addressLineTwo",
                         "placeId": "ChIJY777y0K8hVQRYF7gCZUVMmc"
                     },
-                    "notes": "Last driveway on the left before Tenant Lake Park. House is at the end of a long driveway.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -19181,7 +19828,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/heB8BGrXckMOKJixvFJh",
                     "route": {
@@ -19207,7 +19855,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "EisxODAwIFRleGFzIFN0ICM2LCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh0aGwoWChQKEgmdeUdCiKOFVBFT7-6rrEPvfhIBNg"
                     },
-                    "notes": "Sky View Apartments - Not a secured building, please deliver to apartment door and knock.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -19217,7 +19865,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/iAx8QtrAtwDYUztFKiJl",
                     "route": {
@@ -19236,7 +19885,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "EisxODEyIFRleGFzIFN0ICM3LCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh0aGwoWChQKEglvRA03iKOFVBFDIXS9TD_uCBIBNw"
                     },
-                    "notes": "Park Ridge Apartments* - First floor.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -19246,7 +19895,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/iAx8QtrAtwDYUztFKiJl",
                     "route": {
@@ -19265,7 +19915,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "EiwxODAwIFRleGFzIFN0ICM1OCwgQmVsbGluZ2hhbSwgV0EgOTgyMjksIFVTQSIeGhwKFgoUChIJnXlHQoijhVQRU-_uq6xD734SAjU4"
                     },
-                    "notes": "Sky View Apartments - Alternate phone number is 360-889-1970",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -19275,7 +19925,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/iAx8QtrAtwDYUztFKiJl",
                     "route": {
@@ -19294,7 +19945,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "EiwxODE0IFRleGFzIFN0ICMzNiwgQmVsbGluZ2hhbSwgV0EgOTgyMjksIFVTQSIeGhwKFgoUChIJJ3oaSoijhVQRdXmtqpbxg9ISAjM2"
                     },
-                    "notes": "Park Ridge Apartments* - Unit is on the second floor.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -19304,7 +19955,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/iAx8QtrAtwDYUztFKiJl",
                     "route": {
@@ -19323,7 +19975,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "EisxODAwIFRleGFzIFN0ICM3LCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh0aGwoWChQKEgmdeUdCiKOFVBFT7-6rrEPvfhIBNw"
                     },
-                    "notes": "Sky View Apartments - Recipient lives on lower floor.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -19333,7 +19985,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/iAx8QtrAtwDYUztFKiJl",
                     "route": {
@@ -19352,7 +20005,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -19360,7 +20013,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/iAx8QtrAtwDYUztFKiJl",
                     "route": {
@@ -19379,7 +20033,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "EiwxODAwIFRleGFzIFN0ICM1MSwgQmVsbGluZ2hhbSwgV0EgOTgyMjksIFVTQSIeGhwKFgoUChIJnXlHQoijhVQRU-_uq6xD734SAjUx"
                     },
-                    "notes": "Sky View Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -19389,7 +20043,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/iAx8QtrAtwDYUztFKiJl",
                     "route": {
@@ -19408,7 +20063,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "Ei0xODAwIEFsYWJhbWEgU3QgIzcsIEJlbGxpbmdoYW0sIFdBIDk4MjI5LCBVU0EiHRobChYKFAoSCe1__79vo4VUEbmOlrGmhbkWEgE3"
                     },
-                    "notes": "1800 Place Apartments - Turn on Toledo to access parking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -19418,7 +20073,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/iAx8QtrAtwDYUztFKiJl",
                     "route": {
@@ -19437,7 +20093,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "EisxODAwIFRleGFzIFN0ICMyLCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh0aGwoWChQKEgmdeUdCiKOFVBFT7-6rrEPvfhIBMg"
                     },
-                    "notes": "Sky View Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -19447,7 +20103,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/iAx8QtrAtwDYUztFKiJl",
                     "route": {
@@ -19466,7 +20123,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "EiwxODEwIFRleGFzIFN0ICM1NywgQmVsbGluZ2hhbSwgV0EgOTgyMjksIFVTQSIeGhwKFgoUChIJf3i9O4ijhVQRH0g5ahrxl6QSAjU3"
                     },
-                    "notes": "Park Ridge Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -19476,7 +20133,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/iAx8QtrAtwDYUztFKiJl",
                     "route": {
@@ -19500,7 +20158,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "EiwxODEwIFRleGFzIFN0ICM2OCwgQmVsbGluZ2hhbSwgV0EgOTgyMjksIFVTQSIeGhwKFgoUChIJf3i9O4ijhVQRH0g5ahrxl6QSAjY4"
                     },
-                    "notes": "Park Ridge Apartments* - Second floor, please don't talk to neighbors",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -19510,7 +20168,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/iAx8QtrAtwDYUztFKiJl",
                     "route": {
@@ -19529,7 +20188,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "EiwxODE0IFRleGFzIFN0ICMyNywgQmVsbGluZ2hhbSwgV0EgOTgyMjksIFVTQSIeGhwKFgoUChIJJ3oaSoijhVQRdXmtqpbxg9ISAjI3"
                     },
-                    "notes": "Park Ridge Apartments* - Unit is on the first floor in the building to the left as you come through the gate.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -19539,7 +20198,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/iAx8QtrAtwDYUztFKiJl",
                     "route": {
@@ -19558,7 +20218,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "EiwxODEwIFRleGFzIFN0ICM3MiwgQmVsbGluZ2hhbSwgV0EgOTgyMjksIFVTQSIeGhwKFgoUChIJf3i9O4ijhVQRH0g5ahrxl6QSAjcy"
                     },
-                    "notes": "Park Ridge Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -19568,7 +20228,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/iAx8QtrAtwDYUztFKiJl",
                     "route": {
@@ -19594,7 +20255,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "EjEzMDggVyBDaGFtcGlvbiBTdCAjODAyLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgmzbRjnvKOFVBGDyvFRXLcR8RIDODAy"
                     },
-                    "notes": "Mt Baker Apartments - Deliver to apartment door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -19604,7 +20265,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -19623,7 +20285,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "Ei8xMDIyIE4gU3RhdGUgU3QgIzUxMCwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJUYW5CbmjhVQRvleSuQx8P5ASAzUxMA"
                     },
-                    "notes": "22 North - BFB Delivers",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 28,
                     "orderInfo": {
@@ -19633,7 +20295,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -19652,7 +20315,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -19660,7 +20323,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -19679,7 +20343,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "Ei8xMDIyIE4gU3RhdGUgU3QgIzIwMiwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJUYW5CbmjhVQRvleSuQx8P5ASAzIwMg"
                     },
-                    "notes": "22 North - BFB Delivers",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -19689,7 +20353,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -19708,7 +20373,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "EjAxMDIwIE4gRm9yZXN0IFN0ICMxMDIsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHxodChYKFAoSCe0oOPy4o4VUEbqkgttQXQhaEgMxMDI"
                     },
-                    "notes": "Dorothy Place - BFB Delivers",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 30,
                     "orderInfo": {
@@ -19718,7 +20383,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -19737,7 +20403,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "EjEzMDggVyBDaGFtcGlvbiBTdCAjNDA5LCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgmzbRjnvKOFVBGDyvFRXLcR8RIDNDA5"
                     },
-                    "notes": "Mt Baker Apartments - Deliver to apartment door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -19747,7 +20413,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -19766,7 +20433,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "EjEzMDggVyBDaGFtcGlvbiBTdCAjNjA2LCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgmzbRjnvKOFVBGDyvFRXLcR8RIDNjA2"
                     },
-                    "notes": "Mt Baker Apartments - Deliver to apartment door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -19776,7 +20443,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -19795,7 +20463,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "EjAxMDIwIE4gRm9yZXN0IFN0ICMzMDUsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHxodChYKFAoSCe0oOPy4o4VUEbqkgttQXQhaEgMzMDU"
                     },
-                    "notes": "Dorothy Place - BFB Delivers",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 32,
                     "orderInfo": {
@@ -19805,7 +20473,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -19824,7 +20493,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "Ei8xMDIyIE4gU3RhdGUgU3QgIzUwNywgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJUYW5CbmjhVQRvleSuQx8P5ASAzUwNw"
                     },
-                    "notes": "22 North - BFB Delivers",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 16,
                     "orderInfo": {
@@ -19834,7 +20503,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -19853,7 +20523,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "EjEzMDggVyBDaGFtcGlvbiBTdCAjNTA3LCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgmzbRjnvKOFVBGDyvFRXLcR8RIDNTA3"
                     },
-                    "notes": "Mt Baker Apartments - Deliver to apartment door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -19863,7 +20533,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -19887,7 +20558,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "EjAxMDIwIE4gRm9yZXN0IFN0ICMzMDQsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHxodChYKFAoSCe0oOPy4o4VUEbqkgttQXQhaEgMzMDQ"
                     },
-                    "notes": "Dorothy Place - BFB Delivers",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 36,
                     "orderInfo": {
@@ -19897,7 +20568,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -19916,7 +20588,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "Ei8xMDIyIE4gU3RhdGUgU3QgIzUwNiwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJUYW5CbmjhVQRvleSuQx8P5ASAzUwNg"
                     },
-                    "notes": "22 North - BFB Delivers",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 29,
                     "orderInfo": {
@@ -19926,7 +20598,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -19945,7 +20618,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "Ei8xMDIyIE4gU3RhdGUgU3QgIzQwNSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJUYW5CbmjhVQRvleSuQx8P5ASAzQwNQ"
                     },
-                    "notes": "22 North - BFB Delivers",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 18,
                     "orderInfo": {
@@ -19955,7 +20628,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -19974,7 +20648,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "Ei8xMDIyIE4gU3RhdGUgU3QgIzQxMCwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJUYW5CbmjhVQRvleSuQx8P5ASAzQxMA"
                     },
-                    "notes": "22 North - BFB Delivers",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 24,
                     "orderInfo": {
@@ -19984,7 +20658,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -20003,7 +20678,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "EjAxMDIwIE4gRm9yZXN0IFN0ICMyMDEsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHxodChYKFAoSCe0oOPy4o4VUEbqkgttQXQhaEgMyMDE"
                     },
-                    "notes": "Dorothy Place - BFB Delivers",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 34,
                     "orderInfo": {
@@ -20013,7 +20688,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -20032,7 +20708,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "EjAxMDIwIE4gRm9yZXN0IFN0ICMzMDMsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHxodChYKFAoSCe0oOPy4o4VUEbqkgttQXQhaEgMzMDM"
                     },
-                    "notes": "Dorothy Place - BFB Delivers",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 35,
                     "orderInfo": {
@@ -20042,7 +20718,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -20061,7 +20738,7 @@
                         "addressLineTwo": "stop-1-6 addressLineTwo",
                         "placeId": "Ei8xMDIyIE4gU3RhdGUgU3QgIzMwMSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJUYW5CbmjhVQRvleSuQx8P5ASAzMwMQ"
                     },
-                    "notes": "22 North - BFB Delivers",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 19,
                     "orderInfo": {
@@ -20071,7 +20748,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -20090,7 +20768,7 @@
                         "addressLineTwo": "stop-1-7 addressLineTwo",
                         "placeId": "Ei8xMDIyIE4gU3RhdGUgU3QgIzIwOSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJUYW5CbmjhVQRvleSuQx8P5ASAzIwOQ"
                     },
-                    "notes": "22 North - BFB Delivers",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 26,
                     "orderInfo": {
@@ -20100,7 +20778,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -20119,7 +20798,7 @@
                         "addressLineTwo": "stop-1-8 addressLineTwo",
                         "placeId": "Ei8xMDIyIE4gU3RhdGUgU3QgIzQwMSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJUYW5CbmjhVQRvleSuQx8P5ASAzQwMQ"
                     },
-                    "notes": "22 North - BFB Delivers",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -20129,7 +20808,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -20148,7 +20828,7 @@
                         "addressLineTwo": "stop-1-9 addressLineTwo",
                         "placeId": "Ei8xMDIyIE4gU3RhdGUgU3QgIzIwNCwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJUYW5CbmjhVQRvleSuQx8P5ASAzIwNA"
                     },
-                    "notes": "22 North - BFB Delivers",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -20158,7 +20838,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -20182,7 +20863,7 @@
                         "addressLineTwo": "stop-2-0 addressLineTwo",
                         "placeId": "EjEzMDggVyBDaGFtcGlvbiBTdCAjNjEwLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgmzbRjnvKOFVBGDyvFRXLcR8RIDNjEw"
                     },
-                    "notes": "Mt Baker Apartments - Deliver to apartment door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -20192,7 +20873,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -20211,7 +20893,7 @@
                         "addressLineTwo": "stop-2-1 addressLineTwo",
                         "placeId": "Ei8xMDIyIE4gU3RhdGUgU3QgIzUwOSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJUYW5CbmjhVQRvleSuQx8P5ASAzUwOQ"
                     },
-                    "notes": "22 North - BFB Delivers",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 25,
                     "orderInfo": {
@@ -20221,7 +20903,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -20240,7 +20923,7 @@
                         "addressLineTwo": "stop-2-2 addressLineTwo",
                         "placeId": "EjEzMDggVyBDaGFtcGlvbiBTdCAjNDEyLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgmzbRjnvKOFVBGDyvFRXLcR8RIDNDEy"
                     },
-                    "notes": "Mt Baker Apartments - Deliver to apartment door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -20250,7 +20933,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -20269,7 +20953,7 @@
                         "addressLineTwo": "stop-2-3 addressLineTwo",
                         "placeId": "Ei8xMDIyIE4gU3RhdGUgU3QgIzMwMiwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJUYW5CbmjhVQRvleSuQx8P5ASAzMwMg"
                     },
-                    "notes": "22 North - BFB Delivers",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 23,
                     "orderInfo": {
@@ -20279,7 +20963,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -20298,7 +20983,7 @@
                         "addressLineTwo": "stop-2-4 addressLineTwo",
                         "placeId": "EjAxMDIwIE4gRm9yZXN0IFN0ICMyMDIsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHxodChYKFAoSCe0oOPy4o4VUEbqkgttQXQhaEgMyMDI"
                     },
-                    "notes": "Dorothy Place - BFB Delivers",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 33,
                     "orderInfo": {
@@ -20308,7 +20993,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -20327,7 +21013,7 @@
                         "addressLineTwo": "stop-2-5 addressLineTwo",
                         "placeId": "Ei8xMDIyIE4gU3RhdGUgU3QgIzUwMywgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJUYW5CbmjhVQRvleSuQx8P5ASAzUwMw"
                     },
-                    "notes": "22 North - BFB Delivers",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -20337,7 +21023,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -20356,7 +21043,7 @@
                         "addressLineTwo": "stop-2-6 addressLineTwo",
                         "placeId": "Ei8xMDIyIE4gU3RhdGUgU3QgIzMwNCwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJUYW5CbmjhVQRvleSuQx8P5ASAzMwNA"
                     },
-                    "notes": "22 North - BFB Delivers",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 21,
                     "orderInfo": {
@@ -20366,7 +21053,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -20385,7 +21073,7 @@
                         "addressLineTwo": "stop-2-7 addressLineTwo",
                         "placeId": "Ei8xMDIyIE4gU3RhdGUgU3QgIzIwNSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJUYW5CbmjhVQRvleSuQx8P5ASAzIwNQ"
                     },
-                    "notes": "22 North - BFB Delivers",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 17,
                     "orderInfo": {
@@ -20395,7 +21083,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -20414,7 +21103,7 @@
                         "addressLineTwo": "stop-2-8 addressLineTwo",
                         "placeId": "Ei8xMDIyIE4gU3RhdGUgU3QgIzIwMSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJUYW5CbmjhVQRvleSuQx8P5ASAzIwMQ"
                     },
-                    "notes": "22 North - BFB Delivers",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -20424,7 +21113,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -20443,7 +21133,7 @@
                         "addressLineTwo": "stop-2-9 addressLineTwo",
                         "placeId": "Ei8xMDIyIE4gU3RhdGUgU3QgIzIxMCwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJUYW5CbmjhVQRvleSuQx8P5ASAzIxMA"
                     },
-                    "notes": "22 North - BFB Delivers",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 22,
                     "orderInfo": {
@@ -20453,7 +21143,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -20477,7 +21168,7 @@
                         "addressLineTwo": "stop-3-0 addressLineTwo",
                         "placeId": "EjEzMDggVyBDaGFtcGlvbiBTdCAjMjExLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgmzbRjnvKOFVBGDyvFRXLcR8RIDMjEx"
                     },
-                    "notes": "Mt Baker Apartments - Deliver to apartment door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -20487,7 +21178,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -20506,7 +21198,7 @@
                         "addressLineTwo": "stop-3-1 addressLineTwo",
                         "placeId": "Ei8xMDIyIE4gU3RhdGUgU3QgIzUwMSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJUYW5CbmjhVQRvleSuQx8P5ASAzUwMQ"
                     },
-                    "notes": "22 North - BFB Delivers",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 20,
                     "orderInfo": {
@@ -20516,7 +21208,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -20535,7 +21228,7 @@
                         "addressLineTwo": "stop-3-2 addressLineTwo",
                         "placeId": "EjEzMDggVyBDaGFtcGlvbiBTdCAjNTEwLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgmzbRjnvKOFVBGDyvFRXLcR8RIDNTEw"
                     },
-                    "notes": "Mt Baker Apartments - Deliver to apartment door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -20545,7 +21238,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -20564,7 +21258,7 @@
                         "addressLineTwo": "stop-3-3 addressLineTwo",
                         "placeId": "EjEzMDggVyBDaGFtcGlvbiBTdCAjMzEwLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgmzbRjnvKOFVBGDyvFRXLcR8RIDMzEw"
                     },
-                    "notes": "Mt Baker Apartments - Deliver to apartment door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -20574,7 +21268,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -20593,7 +21288,7 @@
                         "addressLineTwo": "stop-3-4 addressLineTwo",
                         "placeId": "Ei8xMDIyIE4gU3RhdGUgU3QgIzMwOSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJUYW5CbmjhVQRvleSuQx8P5ASAzMwOQ"
                     },
-                    "notes": "22 North - BFB Delivers",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 27,
                     "orderInfo": {
@@ -20603,7 +21298,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -20622,7 +21318,7 @@
                         "addressLineTwo": "stop-3-5 addressLineTwo",
                         "placeId": "EjEzMDggVyBDaGFtcGlvbiBTdCAjNTA0LCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh8aHQoWChQKEgmzbRjnvKOFVBGDyvFRXLcR8RIDNTA0"
                     },
-                    "notes": "Mt Baker Apartments - Deliver to apartment door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -20632,7 +21328,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -20651,7 +21348,7 @@
                         "addressLineTwo": "stop-3-6 addressLineTwo",
                         "placeId": "EjAxMDIwIE4gRm9yZXN0IFN0ICMyMDgsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHxodChYKFAoSCe0oOPy4o4VUEbqkgttQXQhaEgMyMDg"
                     },
-                    "notes": "Dorothy Place - BFB Delivers",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 31,
                     "orderInfo": {
@@ -20661,7 +21358,8 @@
                     },
                     "recipient": {
                         "name": "stop-3-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/kA0gUPHGaHVwuyaoILYY",
                     "route": {
@@ -20687,7 +21385,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "EjExNzA1IEdsYWRzdG9uZSBTdCAjMzA0LCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEglvj2Fv7aOFVBHideDHe4YfLRIDMzA0"
                     },
-                    "notes": "Heart House*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -20697,7 +21395,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/nFaTiKLwCHMsQnBrcvUO",
                     "route": {
@@ -20716,7 +21415,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "EjwxMjEzIFdoYXRjb20gU3QgQmxkZyAjMTEgVW5pdCAjOTQsIEJlbGxpbmdoYW0sIFdBIDk4MjI5LCBVU0EiLRorChYKFAoSCQ8Mt2M1o4VUEYbbFWL47wB4EhFCbGRnICMxMSBVbml0ICM5NA"
                     },
-                    "notes": "Hideaway Apartments - *Access Whatcom St via Nevada St* Drive to the parking lot at the end of building #11 for the easiest access to unit #94. Unit is on the 2nd floor. Disabled veteran with PTSD please don't ring doorbell.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -20726,7 +21425,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/nFaTiKLwCHMsQnBrcvUO",
                     "route": {
@@ -20745,7 +21445,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "EjsxMjEzIFdoYXRjb20gU3QgQmxkZyAjOCBVbml0ICM2MCwgQmVsbGluZ2hhbSwgV0EgOTgyMjksIFVTQSIsGioKFgoUChIJDwy3YzWjhVQRhtsVYvjvAHgSEEJsZGcgIzggVW5pdCAjNjA"
                     },
-                    "notes": "Hideaway Apartments - *Access Whatcom St via Nevada St* Unit is on the top floor on the left of staircase.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -20755,7 +21455,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/nFaTiKLwCHMsQnBrcvUO",
                     "route": {
@@ -20774,7 +21475,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "EjwxMjEzIFdoYXRjb20gU3QgQmxkZyAjMTAgVW5pdCAjODQsIEJlbGxpbmdoYW0sIFdBIDk4MjI5LCBVU0EiLRorChYKFAoSCQ8Mt2M1o4VUEYbbFWL47wB4EhFCbGRnICMxMCBVbml0ICM4NA"
                     },
-                    "notes": "Hideaway Apartments - *Access Whatcom St via Nevada St* Unit is on the 3rd floor, west end. Please deliver to the pink rug by the apartment door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -20784,7 +21485,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/nFaTiKLwCHMsQnBrcvUO",
                     "route": {
@@ -20803,7 +21505,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "Ei0xNDIwIExha2V3YXkgRHIgIzQsIEJlbGxpbmdoYW0sIFdBIDk4MjI5LCBVU0EiHRobChYKFAoSCbXeVvvro4VUEW3laYluDHGoEgE0"
                     },
-                    "notes": "Access to the building is from the parking lot off of Puget St. Recipient's apartment is on the second floor. Follow the covered hallway from the parking lot to the stairway and take a right at the top of the stairs, apartment door is tucked away.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -20813,7 +21515,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/nFaTiKLwCHMsQnBrcvUO",
                     "route": {
@@ -20832,7 +21535,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "EjExNzA1IEdsYWRzdG9uZSBTdCAjMjAxLCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEglvj2Fv7aOFVBHideDHe4YfLRIDMjAx"
                     },
-                    "notes": "Heart House*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -20842,7 +21545,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/nFaTiKLwCHMsQnBrcvUO",
                     "route": {
@@ -20861,7 +21565,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "Ei8xMzIwIExha2V3YXkgRHIgIzI1MSwgQmVsbGluZ2hhbSwgV0EgOTgyMjksIFVTQSIfGh0KFgoUChIJYbK3F8SjhVQRBNDghPUVBLASAzI1MQ"
                     },
-                    "notes": "Foothills Apartments - Turn right on Pacific St behind Papa Murphys then left at the T. Park in client's parking spot, labeled 251, and use the staircase shared by the 1st and 2nd buildings to deliver to the first unit in the 2nd building ( Maples ). Please KNOCK LOUD.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -20871,7 +21575,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/nFaTiKLwCHMsQnBrcvUO",
                     "route": {
@@ -20890,7 +21595,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "EisxNTU1IFB1Z2V0IFN0ICMxLCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh0aGwoWChQKEgkx903Y7KOFVBFQCRWbdzQJQBIBMQ"
                     },
-                    "notes": "Swift Haven Tiny Home Community - If Google maps directions aren't helpful, try searching Maps for 'Swift Haven Tiny Home Community.' Please deliver to recipient's porch.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -20900,7 +21605,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/nFaTiKLwCHMsQnBrcvUO",
                     "route": {
@@ -20919,7 +21625,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -20927,7 +21633,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/nFaTiKLwCHMsQnBrcvUO",
                     "route": {
@@ -20946,7 +21653,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "Ei8xMzIwIExha2V3YXkgRHIgIzE0MSwgQmVsbGluZ2hhbSwgV0EgOTgyMjksIFVTQSIfGh0KFgoUChIJYbK3F8SjhVQRBNDghPUVBLASAzE0MQ"
                     },
-                    "notes": "Foothills Apartments - Turn onto Pacific St (by Papa Murphy's), then left at the end of that street. Recipient lives in the Sequoia building.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -20956,7 +21663,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/nFaTiKLwCHMsQnBrcvUO",
                     "route": {
@@ -20980,7 +21688,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "Ei8xMzIwIExha2V3YXkgRHIgIzEzMSwgQmVsbGluZ2hhbSwgV0EgOTgyMjksIFVTQSIfGh0KFgoUChIJYbK3F8SjhVQRBNDghPUVBLASAzEzMQ"
                     },
-                    "notes": "Foothills Apartments - Turn onto Pacific St (by Papa Murphy's), then left at the end of that street. Building is  Oak,  toward the back, and the first right after the mailboxes. Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -20990,7 +21698,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/nFaTiKLwCHMsQnBrcvUO",
                     "route": {
@@ -21009,7 +21718,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "Ei8xMzIwIExha2V3YXkgRHIgIzI1NSwgQmVsbGluZ2hhbSwgV0EgOTgyMjksIFVTQSIfGh0KFgoUChIJYbK3F8SjhVQRBNDghPUVBLASAzI1NQ"
                     },
-                    "notes": "Foothills Apartments - Turn onto Pacific St (by Papa Murphy's), then left at the end of that street. Building is  Maples,  recipient's unit is upstairs.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -21019,7 +21728,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/nFaTiKLwCHMsQnBrcvUO",
                     "route": {
@@ -21038,7 +21748,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "EjsxMjEzIFdoYXRjb20gU3QgQmxkZyAjOSBVbml0ICM2NywgQmVsbGluZ2hhbSwgV0EgOTgyMjksIFVTQSIsGioKFgoUChIJDwy3YzWjhVQRhtsVYvjvAHgSEEJsZGcgIzkgVW5pdCAjNjc"
                     },
-                    "notes": "Hideaway Apartments - *Access Whatcom St via Nevada St*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -21048,7 +21758,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/nFaTiKLwCHMsQnBrcvUO",
                     "route": {
@@ -21067,7 +21778,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "Ej0xMjEzIFdoYXRjb20gU3QgQmxkZyAjMTIgVW5pdCAjMTEwLCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIi4aLAoWChQKEgkPDLdjNaOFVBGG2xVi-O8AeBISQmxkZyAjMTIgVW5pdCAjMTEw"
                     },
-                    "notes": "Hideaway Apartments - *Access Whatcom St via Nevada St* Unit is on the 2nd floor.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -21077,7 +21788,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/nFaTiKLwCHMsQnBrcvUO",
                     "route": {
@@ -21096,7 +21808,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "EjoxMjEzIFdoYXRjb20gU3QgQmxkZyAjNCBVbml0ICM0LCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIisaKQoWChQKEgkPDLdjNaOFVBGG2xVi-O8AeBIPQmxkZyAjNCBVbml0ICM0"
                     },
-                    "notes": "Hideaway Apartments - *Access Whatcom St via Nevada St* Unit is on the 2nd floor. Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -21106,7 +21818,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/nFaTiKLwCHMsQnBrcvUO",
                     "route": {
@@ -21125,7 +21838,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "EjExNzA1IEdsYWRzdG9uZSBTdCAjMzAxLCBCZWxsaW5naGFtLCBXQSA5ODIyOSwgVVNBIh8aHQoWChQKEglvj2Fv7aOFVBHideDHe4YfLRIDMzAx"
                     },
-                    "notes": "Heart House* - Recipient is recovering from surgery and is physically restricted. Please call on intercom when making delivery so she knows you are there. She will push a chair outside her door for the box to be delivered to.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -21135,7 +21848,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/nFaTiKLwCHMsQnBrcvUO",
                     "route": {
@@ -21161,7 +21875,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "EikyNTAxIEUgU3QgIzYwNiwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJTdtUOpyjhVQRpcgm6YHU07oSAzYwNg"
                     },
-                    "notes": "Washington Square Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -21171,7 +21885,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/qBFagdoT6XQVScQSbUas",
                     "route": {
@@ -21190,7 +21905,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "EikyNTAxIEUgU3QgIzMwMSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJTdtUOpyjhVQRpcgm6YHU07oSAzMwMQ"
                     },
-                    "notes": "Washington Square Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -21200,7 +21915,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/qBFagdoT6XQVScQSbUas",
                     "route": {
@@ -21219,7 +21935,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "EikyNTAxIEUgU3QgIzcwNSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJTdtUOpyjhVQRpcgm6YHU07oSAzcwNQ"
                     },
-                    "notes": "Washington Square Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -21229,7 +21945,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/qBFagdoT6XQVScQSbUas",
                     "route": {
@@ -21248,7 +21965,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "EikyNTAxIEUgU3QgIzYwNSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJTdtUOpyjhVQRpcgm6YHU07oSAzYwNQ"
                     },
-                    "notes": "Washington Square Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -21258,7 +21975,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/qBFagdoT6XQVScQSbUas",
                     "route": {
@@ -21277,7 +21995,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "EikyNTAxIEUgU3QgIzgxMiwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJTdtUOpyjhVQRpcgm6YHU07oSAzgxMg"
                     },
-                    "notes": "Washington Square Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -21287,7 +22005,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/qBFagdoT6XQVScQSbUas",
                     "route": {
@@ -21306,7 +22025,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "EikyNTAxIEUgU3QgIzMwOCwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJTdtUOpyjhVQRpcgm6YHU07oSAzMwOA"
                     },
-                    "notes": "Washington Square Apartments* - Please KNOCK LOUD when you make her delivery.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -21316,7 +22035,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/qBFagdoT6XQVScQSbUas",
                     "route": {
@@ -21335,7 +22055,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "EikyNTAxIEUgU3QgIzUxMywgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJTdtUOpyjhVQRpcgm6YHU07oSAzUxMw"
                     },
-                    "notes": "Washington Square Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -21345,7 +22065,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/qBFagdoT6XQVScQSbUas",
                     "route": {
@@ -21364,7 +22085,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "EikyNTAxIEUgU3QgIzIxMCwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJTdtUOpyjhVQRpcgm6YHU07oSAzIxMA"
                     },
-                    "notes": "Washington Square Apartments* - Please do not leave in lobby, client is disabled and cannot get them from there.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -21374,7 +22095,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/qBFagdoT6XQVScQSbUas",
                     "route": {
@@ -21393,7 +22115,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "EikyNTAxIEUgU3QgIzcxMywgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJTdtUOpyjhVQRpcgm6YHU07oSAzcxMw"
                     },
-                    "notes": "Washington Square Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -21403,7 +22125,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/qBFagdoT6XQVScQSbUas",
                     "route": {
@@ -21422,7 +22145,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -21430,7 +22153,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/qBFagdoT6XQVScQSbUas",
                     "route": {
@@ -21454,7 +22178,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "EikyNTAxIEUgU3QgIzQwNCwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJTdtUOpyjhVQRpcgm6YHU07oSAzQwNA"
                     },
-                    "notes": "Washington Square Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -21464,7 +22188,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/qBFagdoT6XQVScQSbUas",
                     "route": {
@@ -21483,7 +22208,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "EikyNTAxIEUgU3QgIzIwMiwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJTdtUOpyjhVQRpcgm6YHU07oSAzIwMg"
                     },
-                    "notes": "Washington Square Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -21493,7 +22218,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/qBFagdoT6XQVScQSbUas",
                     "route": {
@@ -21512,7 +22238,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "EikyNTAxIEUgU3QgIzUwMiwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJTdtUOpyjhVQRpcgm6YHU07oSAzUwMg"
                     },
-                    "notes": "Washington Square Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -21522,7 +22248,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/qBFagdoT6XQVScQSbUas",
                     "route": {
@@ -21548,7 +22275,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -21556,7 +22283,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/sgMGHeAQ3VHPbBT3KCVn",
                     "route": {
@@ -21575,7 +22303,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "EjEzNDIyIE5vcnRod2VzdCBBdmUgIzI4LCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh4aHAoWChQKEgkd6OOGaaOFVBEkMDQ_XviYNxICMjg"
                     },
-                    "notes": "Cascade West Apartments - Complex entrance is a narrow, one-way driveway.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -21585,7 +22313,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/sgMGHeAQ3VHPbBT3KCVn",
                     "route": {
@@ -21604,7 +22333,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "EjAzNDIyIE5vcnRod2VzdCBBdmUgIzksIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHRobChYKFAoSCR3o44Zpo4VUESQwND9e-Jg3EgE5"
                     },
-                    "notes": "Cascade West Apartments - Complex entrance is a narrow, one-way driveway. Recipient is in the building on the left, upstairs and in the right corner.  Please call 619-677-9070 if you have questions during delivery.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -21614,7 +22343,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/sgMGHeAQ3VHPbBT3KCVn",
                     "route": {
@@ -21633,7 +22363,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "ChIJUyqrHUCjhVQR0IcdeOVl1lM"
                     },
-                    "notes": "Maplewood Junction Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -21643,7 +22373,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/sgMGHeAQ3VHPbBT3KCVn",
                     "route": {
@@ -21662,7 +22393,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "EjIzNDE1IE5vcnRod2VzdCBBdmUgIzEwMywgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJe9XjlC-jhVQRIa8BJBg5koUSAzEwMw"
                     },
-                    "notes": "Country Park Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -21672,7 +22403,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/sgMGHeAQ3VHPbBT3KCVn",
                     "route": {
@@ -21691,7 +22423,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "EjIzNDE5IE5vcnRod2VzdCBBdmUgIzExMywgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSI6GjgKMRIvChQKEgkbXMEuaqOFVBHons1M1NymXhDbGioUChIJYxY63WujhVQRVnI59IXBZOwSAzExMw"
                     },
-                    "notes": "Country Park Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -21701,7 +22433,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/sgMGHeAQ3VHPbBT3KCVn",
                     "route": {
@@ -21720,7 +22453,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "EjIzNDIzIE5vcnRod2VzdCBBdmUgIzIyMiwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIfGh0KFgoUChIJvTHa0mujhVQRvxXdyCFKv-ESAzIyMg"
                     },
-                    "notes": "Country Park Apartments - Apartment is on 2nd floor, please deliver box to the chair outside apartment.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -21730,7 +22463,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/sgMGHeAQ3VHPbBT3KCVn",
                     "route": {
@@ -21749,7 +22483,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "ChIJUyqrHUCjhVQRtsI9h9asQOY"
                     },
-                    "notes": "Maplewood Junction Apartments - Park just behind the cardboard recycling bin and use the staircase at the end of the building to get to the recipient's unit on the second floor.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -21759,7 +22493,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/sgMGHeAQ3VHPbBT3KCVn",
                     "route": {
@@ -21778,7 +22513,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "ChIJUyqrHUCjhVQRn7UOnz4hRKE"
                     },
-                    "notes": "Maplewood Junction Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -21788,7 +22523,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/sgMGHeAQ3VHPbBT3KCVn",
                     "route": {
@@ -21807,7 +22543,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "EjIyODQyIFcgTWFwbGV3b29kIEF2ZSAjMywgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIdGhsKFgoUChIJq7JXnWqjhVQRT6G7yt4AlcgSATM"
                     },
-                    "notes": "Maplewood West Apartments - Building numbers may be difficult to see. The 2842 building is on the side of the parking lot further from Northwest Ave. Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -21817,7 +22553,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/sgMGHeAQ3VHPbBT3KCVn",
                     "route": {
@@ -21841,7 +22578,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "EjAyNjIyIEJpcmNod29vZCBBdmUgIzcsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHRobChYKFAoSCQdXcfRso4VUETS9a1NSg8yTEgE3"
                     },
-                    "notes": "Baker Place - Take the small road to the right of a white house (2624) to access the complex from Birchwood Ave. PLEASE DO NOT LEAVE BOX DIRECTLY IN FRONT OF DOOR, RECIPIENT IS PARTIALLY BLIND AND MAY TRIP IF THEY DON'T SEE IT WHEN THEY OPEN THE DOOR.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -21851,7 +22588,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/sgMGHeAQ3VHPbBT3KCVn",
                     "route": {
@@ -21870,7 +22608,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "EjEzNDIyIE5vcnRod2VzdCBBdmUgIzEzLCBCZWxsaW5naGFtLCBXQSA5ODIyNSwgVVNBIh4aHAoWChQKEgkd6OOGaaOFVBEkMDQ_XviYNxICMTM"
                     },
-                    "notes": "Cascade West Apartments - Complex entrance is a narrow, one-way driveway. Recipient's unit is in the second building, on the ground floor. Access their door from the front side of the building.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -21880,7 +22618,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/sgMGHeAQ3VHPbBT3KCVn",
                     "route": {
@@ -21899,7 +22638,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "EjIyODM2IFcgTWFwbGV3b29kIEF2ZSAjMSwgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIdGhsKFgoUChIJGZ_ChGqjhVQRMKRw8OTK_nQSATE"
                     },
-                    "notes": "Maplewood West Apartments - Building numbers may be difficult to see. The 2836 building is on the side of the parking lot closer to Northwest Ave. Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -21909,7 +22648,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/sgMGHeAQ3VHPbBT3KCVn",
                     "route": {
@@ -21928,7 +22668,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "EjIyODM2IFcgTWFwbGV3b29kIEF2ZSAjMywgQmVsbGluZ2hhbSwgV0EgOTgyMjUsIFVTQSIdGhsKFgoUChIJGZ_ChGqjhVQRMKRw8OTK_nQSATM"
                     },
-                    "notes": "Maplewood West Apartments - Building numbers may be difficult to see. The 2836 building is on the side of the parking lot closer to Northwest Ave.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -21938,7 +22678,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/sgMGHeAQ3VHPbBT3KCVn",
                     "route": {
@@ -21957,7 +22698,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "ChIJVQri8mujhVQRXIAzn992YKw"
                     },
-                    "notes": "The driveway at this address can be tricky to get into and out of, but there is a large parking lot behind the building next door that you can park in. There is a wheelchair ramp in the front of recipient's house.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -21967,7 +22708,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/sgMGHeAQ3VHPbBT3KCVn",
                     "route": {
@@ -21986,7 +22728,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "ChIJfza8ZGmjhVQRzY493t85-Rw"
                     },
-                    "notes": "Southwinds Condominiums",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -21996,7 +22738,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/sgMGHeAQ3VHPbBT3KCVn",
                     "route": {
@@ -22022,7 +22765,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "EjIzNzEgTWVhZG93YnJvb2sgQ3QgIzIyMywgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJd12NL1S7hVQR7cqU05p0so0SAzIyMw"
                     },
-                    "notes": "The Meadows by Vintage - After entering the complex, turn right, then left, and go straight back to the last building on the right side across from the pond.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -22032,7 +22775,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/tnBIFafXKRZ7scuKm5lq",
                     "route": {
@@ -22051,7 +22795,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "EjE0NjI1IENvcmRhdGEgUGt3eSAjMTA5LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgmdwv8SVLuFVBGcVcSjksA-XhIDMTA5"
                     },
-                    "notes": "Vintage at Bellingham - Secured building BUT, recipient would like you to deliver to her exterior entrance which does not require a code to access. As you turn into the complex, take a right and look for the first ground floor unit as you're rounding the corner of the building. You should see a cat bed hanging in her window. Leave delivery at the exterior entrance, may be marked with a  109.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -22061,7 +22805,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/tnBIFafXKRZ7scuKm5lq",
                     "route": {
@@ -22080,7 +22825,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "EjIzODMgTWVhZG93YnJvb2sgQ3QgIzIzMiwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJAzkho1a7hVQRvrxv1beRSXYSAzIzMg"
                     },
-                    "notes": "The Meadows by Vintage - Call during drop off 360-224-8203",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -22090,7 +22835,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/tnBIFafXKRZ7scuKm5lq",
                     "route": {
@@ -22109,7 +22855,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "EjIzMjkgTWVhZG93YnJvb2sgQ3QgIzIwMywgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSI6GjgKMRIvChQKEgmfdUJNUbuFVBH40QgsSWITgRDJAioUChIJ9Zl_ola7hVQRW5PwOgsD06MSAzIwMw"
                     },
-                    "notes": "The Meadows by Vintage",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -22119,7 +22865,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/tnBIFafXKRZ7scuKm5lq",
                     "route": {
@@ -22138,7 +22885,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "ChIJwbn6Da2khVQRkx8u8MFgVTE"
                     },
-                    "notes": "Deliver to the white house just south of the U-Haul center.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -22148,7 +22895,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/tnBIFafXKRZ7scuKm5lq",
                     "route": {
@@ -22167,7 +22915,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "EjIzNzEgTWVhZG93YnJvb2sgQ3QgIzEyMywgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJd12NL1S7hVQR7cqU05p0so0SAzEyMw"
                     },
-                    "notes": "The Meadows by Vintage - After entering the complex, turn right. Recipient's building is all the way in the back corner on the right. Her unit is the bottom one on the right.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -22177,7 +22925,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/tnBIFafXKRZ7scuKm5lq",
                     "route": {
@@ -22196,7 +22945,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "EjIzMzkgTWVhZG93YnJvb2sgQ3QgIzIxMSwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJxSE4p6e7hVQRjfO2Eorb7wcSAzIxMQ"
                     },
-                    "notes": "The Meadows by Vintage",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -22206,7 +22955,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/tnBIFafXKRZ7scuKm5lq",
                     "route": {
@@ -22225,7 +22975,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "ChIJCaSbt1G7hVQR_hBFs_KWcdo"
                     },
-                    "notes": "Front porch",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -22235,7 +22985,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/tnBIFafXKRZ7scuKm5lq",
                     "route": {
@@ -22254,7 +23005,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "EjIzNzkgTWVhZG93YnJvb2sgQ3QgIzMzMSwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJxVCpn1a7hVQR6wYL-Wch5LUSAzMzMQ"
                     },
-                    "notes": "The Meadows by Vintage",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -22264,7 +23015,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/tnBIFafXKRZ7scuKm5lq",
                     "route": {
@@ -22283,7 +23035,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "Ei81MjAgVHJlbW9udCBBdmUgIzIwMywgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJo8XA6FC7hVQR_ZRIRDW0BusSAzIwMw"
                     },
-                    "notes": "Creekside Villas - Recipient's unit is on the second floor.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -22293,7 +23045,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/tnBIFafXKRZ7scuKm5lq",
                     "route": {
@@ -22317,7 +23070,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "EjIzNzkgTWVhZG93YnJvb2sgQ3QgIzEzMCwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJxVCpn1a7hVQR6wYL-Wch5LUSAzEzMA"
                     },
-                    "notes": "The Meadows by Vintage",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -22327,7 +23080,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/tnBIFafXKRZ7scuKm5lq",
                     "route": {
@@ -22346,7 +23100,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "EjIzNzkgTWVhZG93YnJvb2sgQ3QgIzEyOSwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJxVCpn1a7hVQR6wYL-Wch5LUSAzEyOQ"
                     },
-                    "notes": "The Meadows by Vintage - Please deliver to welcome mat at apartment door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -22356,7 +23110,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/tnBIFafXKRZ7scuKm5lq",
                     "route": {
@@ -22375,7 +23130,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -22383,7 +23138,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/tnBIFafXKRZ7scuKm5lq",
                     "route": {
@@ -22402,7 +23158,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "ChIJkcSoC1qjhVQRATbv1rkFwKs"
                     },
-                    "notes": "Darby Estates - Building numbers are posted directly above the building entries. The 512 building is green. Apartment is on the ground floor. When facing the building, the door on the far right is the one closest to the apartment. PLEASE RING DOORBELL.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -22412,7 +23168,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/tnBIFafXKRZ7scuKm5lq",
                     "route": {
@@ -22431,7 +23188,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "EjIzNzUgTWVhZG93YnJvb2sgQ3QgIzEyNiwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJy073JlS7hVQR4r2ds-P26dASAzEyNg"
                     },
-                    "notes": "The Meadows by Vintage",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -22441,7 +23198,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/tnBIFafXKRZ7scuKm5lq",
                     "route": {
@@ -22470,7 +23228,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/tnBIFafXKRZ7scuKm5lq",
                     "route": {
@@ -22496,7 +23255,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "ChIJ4QJuvxm8hVQR03JhT885KDY"
                     },
-                    "notes": "Recipient's driveway is off of Ferndale Terrace, not Vista even though the address is Vista. Exit the roundabout onto Ferndale Terrace and look for the first driveway immediately on your right.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -22506,7 +23265,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/wx6RgEbiOCg6dxrZYkmt",
                     "route": {
@@ -22525,7 +23285,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "EigyMzQ4IE1haW4gU3QgIzcsIEZlcm5kYWxlLCBXQSA5ODI0OCwgVVNBIh0aGwoWChQKEgkrReabJLyFVBFzgtDByR4PABIBNw"
                     },
-                    "notes": "Ferndale Villa Apartments - From the entrance off of Main St, drive straight toward the back and recipient's unit will be on the left.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -22535,7 +23295,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/wx6RgEbiOCg6dxrZYkmt",
                     "route": {
@@ -22554,7 +23315,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "EisyMDc1IFZpc3RhIERyICMyMDcsIEZlcm5kYWxlLCBXQSA5ODI0OCwgVVNBIh8aHQoWChQKEglvKZlfFryFVBEMf3cKLdQzHhIDMjA3"
                     },
-                    "notes": "Ferndale Manor - Secured building with TWO CONFIDENTIAL CODES for entry. The code to the front door is 6839, this will get you into the mail room. To enter the main building from the mail room, enter 9834. If these codes don't work, please call Jennifer. She may direct you to the side door that should be unlocked. It is the one closest to Vista Drive, accessed from the sidewalk. The locked front door is the one accessed from the building's parking lot.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -22564,7 +23325,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/wx6RgEbiOCg6dxrZYkmt",
                     "route": {
@@ -22583,7 +23345,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "EisyMzgxIE1haW4gU3QgYiAyMDMsIEZlcm5kYWxlLCBXQSA5ODI0OCwgVVNBIiEaHwoWChQKEgkXFbjYJLyFVBHIQ2uoyr39LhIFYiAyMDM"
                     },
-                    "notes": "Ferndale Green",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 19,
                     "orderInfo": {
@@ -22593,7 +23355,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/wx6RgEbiOCg6dxrZYkmt",
                     "route": {
@@ -22612,7 +23375,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "EioyMzY5IE1haW4gU3QgIzEwMywgRmVybmRhbGUsIFdBIDk4MjQ4LCBVU0EiOho4CjESLwoUChIJI8i2vyS8hVQRlVbRKt6brSoQwRIqFAoSCddwnhETvIVUEW19-vmHjQJ4EgMxMDM"
                     },
-                    "notes": "Subedar USA Apartments - Recipient's building is the last in the complex.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 18,
                     "orderInfo": {
@@ -22622,7 +23385,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/wx6RgEbiOCg6dxrZYkmt",
                     "route": {
@@ -22651,7 +23415,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/wx6RgEbiOCg6dxrZYkmt",
                     "route": {
@@ -22670,7 +23435,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -22678,7 +23443,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/wx6RgEbiOCg6dxrZYkmt",
                     "route": {
@@ -22707,7 +23473,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/wx6RgEbiOCg6dxrZYkmt",
                     "route": {
@@ -22726,7 +23493,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "ChIJjTfa_p--hVQR5J_ADm53bJM"
                     },
-                    "notes": "Two-story blue-grey house. USE CAUTION on the stairs leading up to the front door, they are VERY slippery when wet.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 20,
                     "orderInfo": {
@@ -22736,7 +23503,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/wx6RgEbiOCg6dxrZYkmt",
                     "route": {
@@ -22755,7 +23523,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "EigyMzQyIE1haW4gU3QgIzIsIEZlcm5kYWxlLCBXQSA5ODI0OCwgVVNBIh0aGwoWChQKEgl56hGiJLyFVBGxFe-I2rLQJRIBMg"
                     },
-                    "notes": "Building # is hidden behind some shrubbery. Look for the building between the two signs for Ferndale Villa Apartments.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -22765,7 +23533,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/wx6RgEbiOCg6dxrZYkmt",
                     "route": {
@@ -22799,7 +23568,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/wx6RgEbiOCg6dxrZYkmt",
                     "route": {
@@ -22818,7 +23588,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "Ei4yMTcwIFNpZGRsZSBMb29wICMxMDQsIEZlcm5kYWxlLCBXQSA5ODI0OCwgVVNBIh8aHQoWChQKEgn_6_YiGLyFVBH6WD7Pb5xVIxIDMTA0"
                     },
-                    "notes": "Recipient's unit is one of the yellow buildings in the loop.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -22828,7 +23598,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/wx6RgEbiOCg6dxrZYkmt",
                     "route": {
@@ -22847,7 +23618,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "ChIJgSZduiS8hVQRVn0qW5NAC1g"
                     },
-                    "notes": "There is a warehouse connected to the back of the house.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 16,
                     "orderInfo": {
@@ -22857,7 +23628,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/wx6RgEbiOCg6dxrZYkmt",
                     "route": {
@@ -22876,7 +23648,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "Eis1NzY5IExlZ29lIEF2ZSAjMTEsIEZlcm5kYWxlLCBXQSA5ODI0OCwgVVNBIjkaNwoxEi8KFAoSCRMoEqgivIVUEQ_OuH9K5D51EIktKhQKEgkpsBOoIryFVBF7skF_TrHLYxICMTE"
                     },
-                    "notes": "Pacific Park Apartments - Recipients unit is on the second floor. Alternate number may be 360-522-4654",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -22886,7 +23658,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/wx6RgEbiOCg6dxrZYkmt",
                     "route": {
@@ -22915,7 +23688,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/wx6RgEbiOCg6dxrZYkmt",
                     "route": {
@@ -22934,7 +23708,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "EisyMDgzIFNodWtzYW4gU3QgIzIsIEZlcm5kYWxlLCBXQSA5ODI0OCwgVVNBIh0aGwoWChQKEgmr2SVfF7yFVBE32CE_gbXrvxIBMg"
                     },
-                    "notes": "Building is across the street from the Ferndale High School parking lot.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -22944,7 +23718,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/wx6RgEbiOCg6dxrZYkmt",
                     "route": {
@@ -22963,7 +23738,7 @@
                         "addressLineTwo": "stop-1-6 addressLineTwo",
                         "placeId": "ChIJ4fpCIhG8hVQRkwgHVuCTtnE"
                     },
-                    "notes": "Look for a white house with a wooden fence. It's best to use the gate off of the alley, not the front gate. Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -22973,7 +23748,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/wx6RgEbiOCg6dxrZYkmt",
                     "route": {
@@ -22992,7 +23768,7 @@
                         "addressLineTwo": "stop-1-7 addressLineTwo",
                         "placeId": "EisyMDgzIFNodWtzYW4gU3QgIzQsIEZlcm5kYWxlLCBXQSA5ODI0OCwgVVNBIh0aGwoWChQKEgmr2SVfF7yFVBE32CE_gbXrvxIBNA"
                     },
-                    "notes": "Building is across the street from the Ferndale High School parking lot.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -23002,7 +23778,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/wx6RgEbiOCg6dxrZYkmt",
                     "route": {
@@ -23021,7 +23798,7 @@
                         "addressLineTwo": "stop-1-8 addressLineTwo",
                         "placeId": "EjA1NzA1IEhlbmRyaWNrc29uIEF2ZSBiNSwgRmVybmRhbGUsIFdBIDk4MjQ4LCBVU0EiHhocChYKFAoSCUU3QkUjvIVUEcgCg4Ip5kcvEgJiNQ"
                     },
-                    "notes": "Mt View Villas - Apt B5 is first lower corner unit, closest to parking lot entrance. Please leave boxes on patio and do not ring doorbell.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -23031,7 +23808,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/wx6RgEbiOCg6dxrZYkmt",
                     "route": {
@@ -23050,7 +23828,7 @@
                         "addressLineTwo": "stop-1-9 addressLineTwo",
                         "placeId": "EikyMzQ4IE1haW4gU3QgIzExLCBGZXJuZGFsZSwgV0EgOTgyNDgsIFVTQSIeGhwKFgoUChIJK0XmmyS8hVQRc4LQwckeDwASAjEx"
                     },
-                    "notes": "Ferndale Villa - Call recipient if you cannot find their unit.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -23060,7 +23838,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/wx6RgEbiOCg6dxrZYkmt",
                     "route": {
@@ -23084,7 +23863,7 @@
                         "addressLineTwo": "stop-2-0 addressLineTwo",
                         "placeId": "ChIJAXcVzyS8hVQR6ghc8SCL0pA"
                     },
-                    "notes": "Subedar USA Apartments - Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 17,
                     "orderInfo": {
@@ -23094,7 +23873,8 @@
                     },
                     "recipient": {
                         "name": "stop-2-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/wx6RgEbiOCg6dxrZYkmt",
                     "route": {
@@ -23130,7 +23910,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/xxaMeOjZA6N9c96GzDeV",
                     "route": {
@@ -23149,7 +23930,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "ChIJn3ilSgujhVQRXjUORfqmzzQ"
                     },
-                    "notes": "Small grey house with white trim and cedar porch. Deliver to porch.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -23159,7 +23940,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/xxaMeOjZA6N9c96GzDeV",
                     "route": {
@@ -23188,7 +23970,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/xxaMeOjZA6N9c96GzDeV",
                     "route": {
@@ -23207,7 +23990,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "ChIJg98xVHGjhVQRGRmrlweYZbg"
                     },
-                    "notes": "Please deliver to the side door of the house (on the left side when facing the house).",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -23217,7 +24000,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/xxaMeOjZA6N9c96GzDeV",
                     "route": {
@@ -23236,7 +24020,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "EicxNjA0IEkgU3QgIzYsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHRobChYKFAoSCRdUiJ-ho4VUEWj8i4yCCdEKEgE2"
                     },
-                    "notes": "Okay for box to be left outside of building.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -23246,7 +24030,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/xxaMeOjZA6N9c96GzDeV",
                     "route": {
@@ -23265,7 +24050,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "ChIJKf6JQqGjhVQRhp-KV1yp7Qo"
                     },
-                    "notes": "Look for the big blue house and deliver to the right of the door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -23275,7 +24060,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/xxaMeOjZA6N9c96GzDeV",
                     "route": {
@@ -23294,7 +24080,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "EicyMjIzIEMgU3QgIzQsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHRobChYKFAoSCRfsYCWZo4VUEdLu6iI1vj3SEgE0"
                     },
-                    "notes": "Building is on the corner of Jenkins and C St.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -23304,7 +24090,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/xxaMeOjZA6N9c96GzDeV",
                     "route": {
@@ -23323,7 +24110,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "ChIJi4vbQwqjhVQR75SJar3i6mQ"
                     },
-                    "notes": "The front gate (on Williams St) is locked. Access the alleyway behind the house from Monroe St and look for a purple ramp. Deliver to the top of the ramp.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -23333,7 +24120,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/xxaMeOjZA6N9c96GzDeV",
                     "route": {
@@ -23362,7 +24150,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/xxaMeOjZA6N9c96GzDeV",
                     "route": {
@@ -23381,7 +24170,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "EicyMjAwIEogU3QgIzYsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHRobChYKFAoSCaPA47Cfo4VUETB6uXwdw_LDEgE2"
                     },
-                    "notes": "Older building located on the corner of J and Irving, looks like a single family home but there are 6 units inside. Enter what looks like the front door and deliver to recipient's door, upstairs.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -23391,7 +24180,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/xxaMeOjZA6N9c96GzDeV",
                     "route": {
@@ -23415,7 +24205,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "EicyMjA5IEcgU3QgIzEsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHRobChYKFAoSCdmSPB2fo4VUEdWmaMjBRxiIEgEx"
                     },
-                    "notes": "Alternative phone number is 360-543-2233.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -23425,7 +24215,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/xxaMeOjZA6N9c96GzDeV",
                     "route": {
@@ -23444,7 +24235,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -23452,7 +24243,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/xxaMeOjZA6N9c96GzDeV",
                     "route": {
@@ -23471,7 +24263,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "Ei0yNTA0IFBlYWJvZHkgU3QgIzMsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHRobChYKFAoSCV8y1n11o4VUESJt-_xt5xjXEgEz"
                     },
-                    "notes": "Recipient's unit is on the main floor with a pink door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -23481,7 +24273,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/xxaMeOjZA6N9c96GzDeV",
                     "route": {
@@ -23500,7 +24293,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "ChIJJ3UAcqGjhVQRcv9Ok_Wa41A"
                     },
-                    "notes": "Please place box by the door on the right side of the porch.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -23510,7 +24303,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/xxaMeOjZA6N9c96GzDeV",
                     "route": {
@@ -23529,7 +24323,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "EioyNjI4IFdlc3QgU3QgIzIsIEJlbGxpbmdoYW0sIFdBIDk4MjI1LCBVU0EiHRobChYKFAoSCVVvChQMo4VUERwBix7F4yX5EgEy"
                     },
-                    "notes": "Duplex. If driving up on West St from Squalicum Creek Park, take the first driveway on the left.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -23539,7 +24333,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/xxaMeOjZA6N9c96GzDeV",
                     "route": {
@@ -23558,7 +24353,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "ChIJT3O2-XSjhVQR6R9BJrTZolY"
                     },
-                    "notes": "Use the alley off of W Connecticut St to access the back of the house. Follow the ramp to deliver to the back door.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -23568,7 +24363,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/xxaMeOjZA6N9c96GzDeV",
                     "route": {
@@ -23594,7 +24390,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "Ei40MTY5IERlZW1lciBSZCAjMTEwLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgkfIn7KpqSFVBFJl8xf8Z_C6xIDMTEw"
                     },
-                    "notes": "Heather Commons",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -23604,7 +24400,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/yr5iXiD9O3esV6YNI73N",
                     "route": {
@@ -23623,7 +24420,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "Ei40MTQxIERlZW1lciBSZCAjMTAzLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgmjztCypqSFVBFSNX4HRlclAhIDMTAz"
                     },
-                    "notes": "Heather Commons",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -23633,7 +24430,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/yr5iXiD9O3esV6YNI73N",
                     "route": {
@@ -23652,7 +24450,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "EjA1NDkgRSBLZWxsb2dnIFJkICMxMDIsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiHxodChYKFAoSCf9ETZqkpIVUETxVHz8oF6BMEgMxMDI"
                     },
-                    "notes": "The North Temezo - Secured building, gate code is  9*8888  There are two entrances to the building. If the gate code doesn't work on one door, please try the other.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -23662,7 +24460,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/yr5iXiD9O3esV6YNI73N",
                     "route": {
@@ -23681,7 +24480,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "Ei4yMTYgUHJpbmNlIEF2ZSAjMjA2LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEglBJG08oaSFVBHEYGsOfeeNuRIDMjA2"
                     },
-                    "notes": "Prince Court Apartments - Unit is on second floor.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -23691,7 +24490,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/yr5iXiD9O3esV6YNI73N",
                     "route": {
@@ -23710,7 +24510,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "Ei4yMTYgUHJpbmNlIEF2ZSAjMjA0LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEglBJG08oaSFVBHEYGsOfeeNuRIDMjA0"
                     },
-                    "notes": "Prince Court Apartments - Unit is on second floor.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -23720,7 +24520,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/yr5iXiD9O3esV6YNI73N",
                     "route": {
@@ -23739,7 +24540,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "Eiw0MzcwIFR1bGwgUmQgIzIxMCwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJb8DtDq-khVQRXDo-fc8VhgYSAzIxMA"
                     },
-                    "notes": "Tullwood Apartments* - last name Taylor",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -23749,7 +24550,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/yr5iXiD9O3esV6YNI73N",
                     "route": {
@@ -23768,7 +24570,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "Eiw0MzgwIFR1bGwgUmQgIzMwNiwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJNTvyBq-khVQRocNrK_X1CksSAzMwNg"
                     },
-                    "notes": "Tullwood Apartments* - last name Kaur. Recipient prefers Punjabi, but does speak some English.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -23778,7 +24580,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/yr5iXiD9O3esV6YNI73N",
                     "route": {
@@ -23797,7 +24600,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "Eiw0MzgwIFR1bGwgUmQgIzIwNSwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJNTvyBq-khVQRocNrK_X1CksSAzIwNQ"
                     },
-                    "notes": "Tullwood Apartments* - last name Hernandez. Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -23807,7 +24610,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/yr5iXiD9O3esV6YNI73N",
                     "route": {
@@ -23826,7 +24630,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -23834,7 +24638,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/yr5iXiD9O3esV6YNI73N",
                     "route": {
@@ -23853,7 +24658,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "EjAzOTYzIFByaW1yb3NlIExuICMxMDEsIEJlbGxpbmdoYW0sIFdBIDk4MjI2LCBVU0EiHxodChYKFAoSCVdBvkCepIVUER4J4F4LoPfnEgMxMDE"
                     },
-                    "notes": "Village at Baker Creek",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -23863,7 +24668,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/yr5iXiD9O3esV6YNI73N",
                     "route": {
@@ -23887,7 +24693,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "Ei4yMTYgUHJpbmNlIEF2ZSAjMjA1LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEglBJG08oaSFVBHEYGsOfeeNuRIDMjA1"
                     },
-                    "notes": "Prince Court Apartments - Unit is on second floor. Recipients are elderly, please deliver to door not landing.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -23897,7 +24703,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/yr5iXiD9O3esV6YNI73N",
                     "route": {
@@ -23916,7 +24723,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "Ei4yMTQgUHJpbmNlIEF2ZSAjMTAyLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgmfQPM5oaSFVBFvCGBTpLK-qhIDMTAy"
                     },
-                    "notes": "Prince Court Apartments",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -23926,7 +24733,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/yr5iXiD9O3esV6YNI73N",
                     "route": {
@@ -23945,7 +24753,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "Ei4yMTQgUHJpbmNlIEF2ZSAjMjA0LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgmfQPM5oaSFVBFvCGBTpLK-qhIDMjA0"
                     },
-                    "notes": "Prince Court Apartments - unit is on second floor.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -23955,7 +24763,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/yr5iXiD9O3esV6YNI73N",
                     "route": {
@@ -23974,7 +24783,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "Eiw0MzcwIFR1bGwgUmQgIzMwNSwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJb8DtDq-khVQRXDo-fc8VhgYSAzMwNQ"
                     },
-                    "notes": "Tullwood Apartments* - last name Richards",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -23984,7 +24793,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/yr5iXiD9O3esV6YNI73N",
                     "route": {
@@ -24003,7 +24813,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "Eiw0MzcwIFR1bGwgUmQgIzQxMCwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJb8DtDq-khVQRXDo-fc8VhgYSAzQxMA"
                     },
-                    "notes": "Tullwood Apartments* - last name Cisneros. If you can't reach Olivia, it's ok to leave her box outside the locked door and text her to say where it is.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -24013,7 +24823,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/yr5iXiD9O3esV6YNI73N",
                     "route": {
@@ -24032,7 +24843,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "ChIJsU9gSZ6khVQRkzZXFpmGwOI"
                     },
-                    "notes": "Please deliver to carport.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -24042,7 +24853,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/yr5iXiD9O3esV6YNI73N",
                     "route": {
@@ -24068,7 +24880,7 @@
                         "addressLineTwo": "stop-0-0 addressLineTwo",
                         "placeId": "ChIJEcEUSGOkhVQRLXlEh_T1Qj8"
                     },
-                    "notes": "Trailview Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 17,
                     "orderInfo": {
@@ -24078,7 +24890,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/zDoFO2roruWT1rNLRdPI",
                     "route": {
@@ -24097,7 +24910,7 @@
                         "addressLineTwo": "stop-0-1 addressLineTwo",
                         "placeId": "Ei4zNDE5IFdvYnVybiBTdCAjMjI3LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgkxumj8h6SFVBHSNFKakJ8bJRIDMjI3"
                     },
-                    "notes": "Evergreen Ridge Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 5,
                     "orderInfo": {
@@ -24107,7 +24920,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/zDoFO2roruWT1rNLRdPI",
                     "route": {
@@ -24126,7 +24940,7 @@
                         "addressLineTwo": "stop-0-2 addressLineTwo",
                         "placeId": "Ei4zNDI3IFdvYnVybiBTdCAjMjUxLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgl7gZH6h6SFVBGiqIn827uyQBIDMjUx"
                     },
-                    "notes": "Evergreen Ridge Apartments* - Building K.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 2,
                     "orderInfo": {
@@ -24136,7 +24950,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/zDoFO2roruWT1rNLRdPI",
                     "route": {
@@ -24155,7 +24970,7 @@
                         "addressLineTwo": "stop-0-3 addressLineTwo",
                         "placeId": "Ei4zNDQ3IFdvYnVybiBTdCAjMTcxLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgmDmjIOiKSFVBHGYk4Mko4GwhIDMTcx"
                     },
-                    "notes": "Evergreen Ridge Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 9,
                     "orderInfo": {
@@ -24165,7 +24980,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/zDoFO2roruWT1rNLRdPI",
                     "route": {
@@ -24184,7 +25000,7 @@
                         "addressLineTwo": "stop-0-4 addressLineTwo",
                         "placeId": "ChIJFw9CDZejhVQRizqiyJSmPqo"
                     },
-                    "notes": null,
+                    "notes": "",
                     "packageCount": null,
                     "stopPosition": 0,
                     "orderInfo": {
@@ -24192,7 +25008,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/zDoFO2roruWT1rNLRdPI",
                     "route": {
@@ -24211,7 +25028,7 @@
                         "addressLineTwo": "stop-0-5 addressLineTwo",
                         "placeId": "Ei4zNDExIFdvYnVybiBTdCAjMjE5LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgljjmkvpqWFVBHZSyxvdUdRSBIDMjE5"
                     },
-                    "notes": "Evergreen Ridge Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 6,
                     "orderInfo": {
@@ -24221,7 +25038,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/zDoFO2roruWT1rNLRdPI",
                     "route": {
@@ -24240,7 +25058,7 @@
                         "addressLineTwo": "stop-0-6 addressLineTwo",
                         "placeId": "Ei4zNDE5IFdvYnVybiBTdCAjMjMxLCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgkxumj8h6SFVBHSNFKakJ8bJRIDMjMx"
                     },
-                    "notes": "Evergreen Ridge Apartments* - Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 3,
                     "orderInfo": {
@@ -24250,7 +25068,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/zDoFO2roruWT1rNLRdPI",
                     "route": {
@@ -24269,7 +25088,7 @@
                         "addressLineTwo": "stop-0-7 addressLineTwo",
                         "placeId": "Ei8yNDEyIFJpbWxhbmQgRHIgIzQxOCwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJwz3cSiSlhVQR_jZSWJYhH1wSAzQxOA"
                     },
-                    "notes": "Trailview Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 16,
                     "orderInfo": {
@@ -24279,7 +25098,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/zDoFO2roruWT1rNLRdPI",
                     "route": {
@@ -24298,7 +25118,7 @@
                         "addressLineTwo": "stop-0-8 addressLineTwo",
                         "placeId": "Ei8yNDEyIFJpbWxhbmQgRHIgIzIxMCwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJwz3cSiSlhVQR_jZSWJYhH1wSAzIxMA"
                     },
-                    "notes": "Trailview Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 15,
                     "orderInfo": {
@@ -24308,7 +25128,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-8 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/zDoFO2roruWT1rNLRdPI",
                     "route": {
@@ -24327,7 +25148,7 @@
                         "addressLineTwo": "stop-0-9 addressLineTwo",
                         "placeId": "Ei4zNDE5IFdvYnVybiBTdCAjMTI5LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgkxumj8h6SFVBHSNFKakJ8bJRIDMTI5"
                     },
-                    "notes": "Evergreen Ridge Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 4,
                     "orderInfo": {
@@ -24337,7 +25158,8 @@
                     },
                     "recipient": {
                         "name": "stop-0-9 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/zDoFO2roruWT1rNLRdPI",
                     "route": {
@@ -24361,7 +25183,7 @@
                         "addressLineTwo": "stop-1-0 addressLineTwo",
                         "placeId": "Ei4zNDA3IFdvYnVybiBTdCAjMjA5LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgk7eVkAiKSFVBED3t_UmRxZcBIDMjA5"
                     },
-                    "notes": "Evergreen Ridge Apartments* - If entering the complex from Woburn, take the first left and the recipient's unit is on the second floor of the building all the way at the end. If you need to contact recipient and they aren't answering, please try their son at 564-209-1530.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 7,
                     "orderInfo": {
@@ -24371,7 +25193,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-0 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/zDoFO2roruWT1rNLRdPI",
                     "route": {
@@ -24390,7 +25213,7 @@
                         "addressLineTwo": "stop-1-1 addressLineTwo",
                         "placeId": "Ei8yNDEyIFJpbWxhbmQgRHIgIzQyMywgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJwz3cSiSlhVQR_jZSWJYhH1wSAzQyMw"
                     },
-                    "notes": "Trailview Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 14,
                     "orderInfo": {
@@ -24400,7 +25223,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-1 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/zDoFO2roruWT1rNLRdPI",
                     "route": {
@@ -24419,7 +25243,7 @@
                         "addressLineTwo": "stop-1-2 addressLineTwo",
                         "placeId": "Ei4zNDM1IFdvYnVybiBTdCAjMTQ2LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEglLe1EGiKSFVBGPSJ5itp2KehIDMTQ2"
                     },
-                    "notes": "Evergreen Ridge Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 10,
                     "orderInfo": {
@@ -24429,7 +25253,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-2 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/zDoFO2roruWT1rNLRdPI",
                     "route": {
@@ -24448,7 +25273,7 @@
                         "addressLineTwo": "stop-1-3 addressLineTwo",
                         "placeId": "Ei8yNDEyIFJpbWxhbmQgRHIgIzIwMSwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJwz3cSiSlhVQR_jZSWJYhH1wSAzIwMQ"
                     },
-                    "notes": "Trailview Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 13,
                     "orderInfo": {
@@ -24458,7 +25283,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-3 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/zDoFO2roruWT1rNLRdPI",
                     "route": {
@@ -24477,7 +25303,7 @@
                         "addressLineTwo": "stop-1-4 addressLineTwo",
                         "placeId": "Ei8yNDEyIFJpbWxhbmQgRHIgIzQwOSwgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJwz3cSiSlhVQR_jZSWJYhH1wSAzQwOQ"
                     },
-                    "notes": "Trailview Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 12,
                     "orderInfo": {
@@ -24487,7 +25313,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-4 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/zDoFO2roruWT1rNLRdPI",
                     "route": {
@@ -24506,7 +25333,7 @@
                         "addressLineTwo": "stop-1-5 addressLineTwo",
                         "placeId": "Ei8yNDEyIFJpbWxhbmQgRHIgIzIxMywgQmVsbGluZ2hhbSwgV0EgOTgyMjYsIFVTQSIfGh0KFgoUChIJwz3cSiSlhVQR_jZSWJYhH1wSAzIxMw"
                     },
-                    "notes": "Trailview Apartments*",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 11,
                     "orderInfo": {
@@ -24516,7 +25343,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-5 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood3"
                     },
                     "plan": "plans/zDoFO2roruWT1rNLRdPI",
                     "route": {
@@ -24535,7 +25363,7 @@
                         "addressLineTwo": "stop-1-6 addressLineTwo",
                         "placeId": "Ei4zNDQ3IFdvYnVybiBTdCAjMTY5LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgmDmjIOiKSFVBHGYk4Mko4GwhIDMTY5"
                     },
-                    "notes": "Evergreen Ridge Apartments* - Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 8,
                     "orderInfo": {
@@ -24545,7 +25373,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-6 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood1"
                     },
                     "plan": "plans/zDoFO2roruWT1rNLRdPI",
                     "route": {
@@ -24564,7 +25393,7 @@
                         "addressLineTwo": "stop-1-7 addressLineTwo",
                         "placeId": "Ei4zNDMxIFdvYnVybiBTdCAjMjM4LCBCZWxsaW5naGFtLCBXQSA5ODIyNiwgVVNBIh8aHQoWChQKEgmva8z1h6SFVBEmjz7A_Up-jRIDMjM4"
                     },
-                    "notes": "Evergreen Ridge Apartments* - Recipient is Spanish-speaking.",
+                    "notes": "",
                     "packageCount": 1,
                     "stopPosition": 1,
                     "orderInfo": {
@@ -24574,7 +25403,8 @@
                     },
                     "recipient": {
                         "name": "stop-1-7 recipient",
-                        "phone": 2015550123
+                        "phone": 2015550123,
+                        "externalId": "neighborhood2"
                     },
                     "plan": "plans/zDoFO2roruWT1rNLRdPI",
                     "route": {

--- a/tests/unit/test_read_circuit.py
+++ b/tests/unit/test_read_circuit.py
@@ -949,6 +949,6 @@ def test_set_routes_df_values_sets_neighborhoods() -> None:
         "YORK",
     ]
 
-    returned_df = _set_routes_df_values(routes_df=routes_df, verbose=False)
+    returned_df = _set_routes_df_values(routes_df=routes_df)
 
     assert returned_df[Columns.NEIGHBORHOOD].tolist() == expected_neighborhoods

--- a/tests/unit/test_write_to_circuit.py
+++ b/tests/unit/test_write_to_circuit.py
@@ -1639,3 +1639,36 @@ def test_delete_plan_return(fail: bool, error_context: AbstractContextManager) -
         with error_context:
             deletion = delete_plan(plan_id=plan_id)
             assert deletion == (not fail)
+
+
+@pytest.mark.parametrize(
+    "neighborhood",
+    [
+        None,
+        "Neighborhood 1",
+    ],
+)
+@typechecked
+def test_build_stop_array_adds_externalId(neighborhood: None | str) -> None:
+    """_build_stop_array assigns "Neighborhood" field to `recipient_dict` `externalId`."""
+    stop_df = pd.DataFrame(
+        {
+            CircuitColumns.ADDRESS_NAME: ["ADDRESS_NAME"],
+            CircuitColumns.ADDRESS_LINE_1: ["ADDRESS_LINE_1"],
+            CircuitColumns.ADDRESS_LINE_2: ["ADDRESS_LINE_2"],
+            CircuitColumns.STATE: ["STATE"],
+            CircuitColumns.ZIP: ["ZIP"],
+            CircuitColumns.COUNTRY: ["COUNTRY"],
+            Columns.PRODUCT_TYPE: ["PRODUCT_TYPE"],
+            Columns.ORDER_COUNT: [1],
+            Columns.EMAIL: ["EMAIL"],
+            Columns.NEIGHBORHOOD: [neighborhood],
+        }
+    )
+
+    stop_array = _build_stop_array(route_stops=stop_df, driver_id="driver_id")
+
+    assert (
+        stop_array[0][CircuitColumns.RECIPIENT].get(CircuitColumns.EXTERNAL_ID)
+        == neighborhood
+    )


### PR DESCRIPTION
Uses `recipient.externalId` field to carry neighborhood from input to output, addressing https://github.com/crickets-and-comb/bfb_delivery/issues/60.
Also updates some mock data.

Bonus:
- Removes unused verbose flag from a helper function.