### PR TITLE
Debug/kaleb coberly/duplicates name col is list

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ CLI tools (see docs for more information):
 - format_combined_routes
 
 
-## Dev
+## Developers
 
 ### Setting up shared tools
 
@@ -182,6 +182,10 @@ Then, run it from the repo directory:
 That will run `.github/workflows/CI_CD.yml`. Also, since `act` doesn't work with Mac and Windows architecture, it skips/fails them, but it is a good test of the Linux build.
 
 NOTE: To be more accurate, we've overridden `run-act` to create a local `CI_CD_act.yml` (which we ignore with Git) as a copy of `CI_CD.yml` and replace one of the workflow call URLs with a relative path. We use a relative path because otherwise `act` will not honor the overridden `full-test` make target and will run the shared version. That will fail because the shared `full-test` target includes running integration and e2e tests, which this repo does not include.
+
+### See also
+
+See also [https://cricketsandcomb.org/bfb_delivery/developers.html](https://cricketsandcomb.org/bfb_delivery/developers.html).
 
 ## Acknowledgments
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bfb_delivery
-version = 1.0.4
+version = 1.0.5
 description = Tools to help plan deliveries for Bellingham Food Bank.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/bfb_delivery/lib/dispatch/write_to_circuit.py
+++ b/src/bfb_delivery/lib/dispatch/write_to_circuit.py
@@ -749,14 +749,6 @@ def _assign_driver(  # noqa: C901
                     ],
                 ]
             )
-    # TODO: List as value in "depots" col and dict as value in "routeOverrides" col unhashable
-    # and suddenly breaking pandas.DataFrame.drop_duplicates in next line.
-    # Find out why we're getting "depots" and "routeOverrides" columns in `drivers_df`.
-    # Were the columns there in previous runs?
-    # Were they different value types?
-    # Guessing something changed in Circuit API response, but can't be sure since we don't
-    # save the drivers_df to an intermediate file like the plans_df etc.
-
     # Using ID with name/email as added validation of our assumptions about uniqueness.
     # Should break more loudly if so than if we only used ID or name/email compound key.
     id_cols = [CircuitColumns.ID, CircuitColumns.NAME, CircuitColumns.EMAIL]

--- a/src/bfb_delivery/lib/dispatch/write_to_circuit.py
+++ b/src/bfb_delivery/lib/dispatch/write_to_circuit.py
@@ -749,7 +749,20 @@ def _assign_driver(  # noqa: C901
                     ],
                 ]
             )
-    best_guesses = best_guesses.drop_duplicates().sort_values(by=CircuitColumns.NAME)
+    # TODO: List as value in "depots" col and dict as value in "routeOverrides" col unhashable
+    # and suddenly breaking pandas.DataFrame.drop_duplicates in next line.
+    # Find out why we're getting "depots" and "routeOverrides" columns in `drivers_df`.
+    # Were the columns there in previous runs?
+    # Were they different value types?
+    # Guessing something changed in Circuit API response, but can't be sure since we don't
+    # save the drivers_df to an intermediate file like the plans_df etc.
+
+    # Using ID with name/email as added validation of our assumptions about uniqueness.
+    # Should break more loudly if so than if we only used ID or name/email compound key.
+    id_cols = [CircuitColumns.ID, CircuitColumns.NAME, CircuitColumns.EMAIL]
+    best_guesses = best_guesses.drop_duplicates(subset=id_cols).sort_values(
+        by=CircuitColumns.NAME
+    )
 
     print(f"\nRoute {route_title}:\nBest guesses:")
     for idx, driver in best_guesses.iterrows():


### PR DESCRIPTION
Fixes bug where columns (newly added in Circuit response?) in `driver_df` (in `bfb_delivery.lib.dispatch.write_to_circuit._assign_driver()`), "depots" and "routeOverrides" were causing `pandas.DataFrame.drop_duplicates()` (naked call) to fail because those columns contained unhashable types (list and dict, respectively). Now subsets the drop duplicates call to "id", "name", and "email".

Also adds note in README for developers to see developer docs on doc site.