### PR TITLE
Bugfix/kaleb coberly/pin flake8 black

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,6 @@ doc =
 qc =
     bandit>=1.7
     black>=23.3
-    black[jupyter]>=23.3
     flake8>=6.0.0
     flake8-annotations>=3.0.1
     flake8-bandit>=4.1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bfb_delivery
-version = 1.0.16
+version = 1.0.17
 description = Tools to help plan deliveries for Bellingham Food Bank.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,12 +64,12 @@ doc =
 
 qc =
     bandit>=1.7
-    black>=23.3,<25.9.0
+    black>=23.3
     black[jupyter]>=23.3
     flake8>=6.0.0
     flake8-annotations>=3.0.1
     flake8-bandit>=4.1.1
-    flake8-black>=0.3.6
+    flake8-black>=0.4.0
     flake8-bugbear>=23.7.10
     flake8-docstrings>=1.7.0
     flake8-isort>=6.0.0


### PR DESCRIPTION
Pins to `flake8-black` release that pins `black` to avoid breaking release.
Also removes unnecessary `flake8-black[jupyter]`.