### PR TITLE
Bugfix/kaleb coberly/no address name

### DIFF
--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -81,6 +81,8 @@ jobs:
     uses: crickets-and-comb/shared/.github/workflows/CI_win.yml@main
     secrets:
       CHECKOUT_SHARED: ${{ secrets.CHECKOUT_SHARED }}
+      OSSINDEX_USERNAME: ${{ secrets.OSSINDEX_USERNAME }}
+      OSSINDEX_PASSWORD: ${{ secrets.OSSINDEX_PASSWORD }}
       SAFETY_API_KEY: ${{ secrets.SAFETY_API_KEY }}
 
   build-dist:

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -25,10 +25,10 @@ At a high level, the data structure is:
 .. mermaid::
 
     graph TD;
-        A[Plan] -->|m:m| B[Drivers]
-        A -->|1:m| C[Stops]
-        B -->|1:m| D[Routes]
-        D -->|1:m| C[Stops]
+        plan[Plan] -->|m:m| drivers[Drivers]
+        plan -->|1:m| stops[Stops]
+        drivers -->|1:m| routes[Routes]
+        routes -->|1:m| stops[Stops]
 
 So, in Circuit, a plan can have multiple drivers, and routes only get created when a plan with stops and drivers is created and optimized. Optimization allocates stops to the drivers in the plan, with one route per driver in the plan. A driver may have multiple routes, and plan may have multiple routes.
 
@@ -37,10 +37,10 @@ But, for the Bellingham Food Bank, there is only ever one route per plan. They o
 .. mermaid::
 
     graph TD;
-        A[Plan] -->|**m:1**| B[Drivers]
-        A -->|1:m| C[Stops]
-        B -->|1:m| D[Routes]
-        D -->|1:m| C[Stops]
+        plan[Plan] -->|**m:1**| drivers[Drivers]
+        plan -->|1:m| stops[Stops]
+        drivers -->|1:m| routes[Routes]
+        routes -->|1:m| stops[Stops]
 
 
 Additionally, the data come from the API in a JSON structure that is not normalized. So, routes docs do contain plan IDs, and plan docs contain route IDs. And, the food bank is not ready to maintain an RDBMS for this purpose.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bfb_delivery
-version = 1.0.17
+version = 1.0.18
 description = Tools to help plan deliveries for Bellingham Food Bank.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bfb_delivery
-version = 1.0.19
+version = 1.0.20
 description = Tools to help plan deliveries for Bellingham Food Bank.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bfb_delivery
-version = 1.0.18
+version = 1.0.19
 description = Tools to help plan deliveries for Bellingham Food Bank.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/bfb_delivery/lib/constants.py
+++ b/src/bfb_delivery/lib/constants.py
@@ -53,7 +53,6 @@ class CircuitColumns:
 
     ACTIVE: Final[str] = "active"
     ADDRESS: Final[str] = "address"
-    ADDRESS_NAME: Final[str] = "addressName"
     ADDRESS_LINE_1: Final[str] = "addressLineOne"
     ADDRESS_LINE_2: Final[str] = "addressLineTwo"
     ALLOWED_DRIVERS: Final[str] = "allowedDrivers"

--- a/src/bfb_delivery/lib/dispatch/write_to_circuit.py
+++ b/src/bfb_delivery/lib/dispatch/write_to_circuit.py
@@ -820,7 +820,6 @@ def _assign_driver(  # noqa: C901
 @typechecked
 def _parse_addresses(stops_df: pd.DataFrame) -> pd.DataFrame:
     """Parse addresses for each route."""
-    stops_df[CircuitColumns.ADDRESS_NAME] = stops_df[Columns.ADDRESS]
     stops_df[CircuitColumns.ADDRESS_LINE_1] = ""
     stops_df[CircuitColumns.ADDRESS_LINE_2] = ""
     stops_df[CircuitColumns.STATE] = "WA"
@@ -917,7 +916,6 @@ def _build_stop_array(route_stops: pd.DataFrame, driver_id: str) -> list[dict[st
     for _, stop_row in route_stops.iterrows():
         stop = {
             CircuitColumns.ADDRESS: {
-                CircuitColumns.ADDRESS_NAME: stop_row[CircuitColumns.ADDRESS_NAME],
                 CircuitColumns.ADDRESS_LINE_1: stop_row[CircuitColumns.ADDRESS_LINE_1],
                 CircuitColumns.ADDRESS_LINE_2: stop_row[CircuitColumns.ADDRESS_LINE_2],
                 CircuitColumns.STATE: stop_row[CircuitColumns.STATE],

--- a/tests/unit/test_write_to_circuit.py
+++ b/tests/unit/test_write_to_circuit.py
@@ -1074,7 +1074,6 @@ def test_upload_stops_calls(
     """Test that _upload_stops uploads stops correctly."""
     plan_df_initialized = request.getfixturevalue(initialization_fixture)
     mock_stop_upload = request.getfixturevalue(upload_fixture)
-
     _ = _upload_stops(stops_df=mock_stops_df, plan_df=plan_df_initialized, verbose=False)
 
     for plan_id, expected_stop_array in mock_stop_upload.items():
@@ -1122,6 +1121,30 @@ def test_upload_stops_return(
     )
 
     pd.testing.assert_frame_equal(stops_uploaded, expected_stops_uploaded)
+
+
+@typechecked
+def test_upload_stops_no_addressName(
+    mock_stops_df: pd.DataFrame,
+    mock_plan_df_plans_initialized: pd.DataFrame,
+    mock_stop_upload: dict[str, list],
+    requests_mock: Mocker,  # noqa: F811
+) -> None:
+    """Test that _upload_stops does not include addressName."""
+    _ = _upload_stops(
+        stops_df=mock_stops_df, plan_df=mock_plan_df_plans_initialized, verbose=False
+    )
+
+    for plan_id, _ in mock_stop_upload.items():
+        expected_url = f"{CIRCUIT_URL}/{plan_id}/stops:import"
+        matching_requests = [
+            req for req in requests_mock.request_history if req.url == expected_url
+        ]
+        assert len(matching_requests) == 1
+
+        actual_payload = matching_requests[0].json()
+        for stop in actual_payload:
+            assert "addressName" not in stop[CircuitColumns.ADDRESS].keys()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_write_to_circuit.py
+++ b/tests/unit/test_write_to_circuit.py
@@ -1654,7 +1654,6 @@ def test_build_stop_array_adds_externalId(neighborhood: None | str) -> None:
     """_build_stop_array assigns "Neighborhood" field to `recipient_dict` `externalId`."""
     stop_df = pd.DataFrame(
         {
-            CircuitColumns.ADDRESS_NAME: ["ADDRESS_NAME"],
             CircuitColumns.ADDRESS_LINE_1: ["ADDRESS_LINE_1"],
             CircuitColumns.ADDRESS_LINE_2: ["ADDRESS_LINE_2"],
             CircuitColumns.STATE: ["STATE"],


### PR DESCRIPTION
Drops `addressName` in stop uploads.

We were passing the whole address in as `addressName` out of confusion about what Circuit was doing with the fields. The post fields include `addressName`, `addressLineOne`, `addressLineTwo`, `city`, `state`, `zip` ... But, the returned fields are only `address`, `addressLineOne`, and `addressLineTwo`. Circuit adds `addressName` to the beginning of `addressLineOne`, then does some deduplication. So, we didn't notice a problem until they changed the deduplication so that it stops deduplicating.

Removing `addressName` altogether, since we don't pass the recipient names to the address, fixes the problem.

That said, we may need to change the way we create `addressLineTwo` in the future if they stop deduplicating that too. We currently put city/state/zip in `addressLineTwo`. If we stop doing that and only pass apartment numbers to `addressLineTwo`, then Circuit will add to the end of `addressLineTwo` the city/state/zip that we passed in to those specific fields. Saving that for another PR since this needs to go into prod for tomorrow.

(Also makes a Mermaid chart easier to read in the markdown. Unrelated porkbarrel.)