### PR TITLE
Bugfix/kaleb coberly/pandera typing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
     click>=8.1.8,<9.0.0
     comb_utils>=0.2.0,<1.0.0
     email-validator>=2.2.0,<3.0.0
+    numpy<2.4.0
     openpyxl>=3.1.5,<4.0.0
     pandas>=2.2.3,<3.0.0
     pandera[extensions]>=0.22.1,<0.23.0


### PR DESCRIPTION
Pins to `numpy<2.4.0`, to avoid Pandera typechecking errors. (NumPy release was mainly for Python 3.14 free threading, which we're not supporting yet. And, the https://scientific-python.org/specs/spec-0000/#support-window is squarely in NumPy 2.3.0 anyway.)