### PR TITLE
nltk develop

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,8 @@ install_requires =
     click>=8.1.8,<9.0.0
     comb_utils>=0.5.3,<1.0.0
     email-validator>=2.2.0,<3.0.0
+    # Until nltk 3.9.3 is released: https://github.com/nltk/nltk/pull/3503
+    nltk @ git+https://github.com/nltk/nltk.git@develop
     openpyxl>=3.1.5,<4.0.0
     pandera[extensions]>=0.29.0,<0.30.0
     phonenumbers>=8.13.52,<9.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bfb_delivery
-version = 2.0.11
+version = 2.0.12
 description = Tools to help plan deliveries for Bellingham Food Bank.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Partially addresses https://github.com/crickets-and-comb/shared/issues/152
Pins to `nltk@develop` until 3.9.3 released to address CVE-2025-14009.
Updates `shared` Git submodule to ignore for now.